### PR TITLE
[round-1] 회원가입, 내 정보 조회, 포인트 조회, 포인트 충전 기능 구현

### DIFF
--- a/apps/commerce-api/src/main/kotlin/com/loopers/application/point/PointFacade.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/application/point/PointFacade.kt
@@ -1,0 +1,23 @@
+package com.loopers.application.point
+
+import com.loopers.domain.point.PointService
+import com.loopers.domain.user.UserService
+import com.loopers.support.error.CoreException
+import com.loopers.support.error.ErrorType.NOT_FOUND
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+import java.math.BigDecimal
+
+@Component
+class PointFacade(private val userService: UserService, private val pointService: PointService) {
+
+    @Transactional(readOnly = true)
+    fun myPoints(userId: String): PointInfo {
+        userService.find(userId)
+            ?: throw CoreException(NOT_FOUND, "해당 사용자를 찾을 수 없습니다.")
+
+        return pointService.find(userId)
+            ?.let { PointInfo.from(it) }
+            ?: PointInfo(userId = userId, balance = BigDecimal.ZERO)
+    }
+}

--- a/apps/commerce-api/src/main/kotlin/com/loopers/application/point/PointFacade.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/application/point/PointFacade.kt
@@ -1,5 +1,6 @@
 package com.loopers.application.point
 
+import com.loopers.domain.point.PointCommand
 import com.loopers.domain.point.PointService
 import com.loopers.domain.user.UserService
 import com.loopers.support.error.CoreException
@@ -19,5 +20,14 @@ class PointFacade(private val userService: UserService, private val pointService
         return pointService.find(userId)
             ?.let { PointInfo.from(it) }
             ?: PointInfo(userId = userId, balance = BigDecimal.ZERO)
+    }
+
+    @Transactional
+    fun charge(command: PointCommand.Charge): PointInfo {
+        userService.find(command.userId)
+            ?: throw CoreException(NOT_FOUND, "해당 사용자를 찾을 수 없습니다.")
+
+        return pointService.charge(command)
+            .let { PointInfo.from(it) }
     }
 }

--- a/apps/commerce-api/src/main/kotlin/com/loopers/application/point/PointInfo.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/application/point/PointInfo.kt
@@ -1,0 +1,14 @@
+package com.loopers.application.point
+
+import com.loopers.domain.point.Point
+import java.math.BigDecimal
+
+data class PointInfo(val userId: String, val balance: BigDecimal) {
+    companion object {
+        fun from(point: Point): PointInfo =
+            PointInfo(
+                userId = point.userId,
+                balance = point.balance.stripTrailingZeros(),
+            )
+    }
+}

--- a/apps/commerce-api/src/main/kotlin/com/loopers/application/user/UserFacade.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/application/user/UserFacade.kt
@@ -4,6 +4,7 @@ import com.loopers.domain.user.UserCommand
 import com.loopers.domain.user.UserService
 import com.loopers.support.error.CoreException
 import com.loopers.support.error.ErrorType.CONFLICT
+import com.loopers.support.error.ErrorType.NOT_FOUND
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional
 
@@ -18,4 +19,10 @@ class UserFacade(private val userService: UserService) {
         return userService.create(command)
             .let { UserInfo.from(it) }
     }
+
+    @Transactional(readOnly = true)
+    fun me(userId: String): UserInfo =
+        userService.find(userId)
+            ?.let { UserInfo.from(it) }
+            ?: throw CoreException(NOT_FOUND, "해당 사용자를 찾을 수 없습니다.")
 }

--- a/apps/commerce-api/src/main/kotlin/com/loopers/application/user/UserFacade.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/application/user/UserFacade.kt
@@ -1,0 +1,21 @@
+package com.loopers.application.user
+
+import com.loopers.domain.user.UserCommand
+import com.loopers.domain.user.UserService
+import com.loopers.support.error.CoreException
+import com.loopers.support.error.ErrorType.CONFLICT
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+
+@Component
+class UserFacade(private val userService: UserService) {
+
+    @Transactional
+    fun signup(command: UserCommand.Create): UserInfo {
+        userService.find(command.userId)
+            ?.let { throw CoreException(CONFLICT, "동일한 ID로 이미 가입된 계정이 존재합니다.") }
+
+        return userService.create(command)
+            .let { UserInfo.from(it) }
+    }
+}

--- a/apps/commerce-api/src/main/kotlin/com/loopers/application/user/UserInfo.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/application/user/UserInfo.kt
@@ -1,0 +1,22 @@
+package com.loopers.application.user
+
+import com.loopers.domain.user.Gender
+import com.loopers.domain.user.User
+import java.time.LocalDate
+
+data class UserInfo(
+    val userId: String,
+    val email: String,
+    val birthdate: LocalDate,
+    val gender: Gender,
+) {
+    companion object {
+        fun from(user: User): UserInfo =
+            UserInfo(
+                userId = user.userId,
+                email = user.email,
+                birthdate = user.birthdate,
+                gender = user.gender,
+            )
+    }
+}

--- a/apps/commerce-api/src/main/kotlin/com/loopers/domain/point/Point.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/domain/point/Point.kt
@@ -1,0 +1,23 @@
+package com.loopers.domain.point
+
+import com.loopers.domain.BaseEntity
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Table
+import java.math.BigDecimal
+
+@Entity
+@Table(name = "point")
+class Point(userId: String, balance: BigDecimal = BigDecimal.ZERO) : BaseEntity() {
+
+    @Column(name = "user_id", nullable = false)
+    val userId: String = userId
+
+    @Column(name = "balance", nullable = false)
+    var balance: BigDecimal = balance
+        private set
+
+    init {
+        require(balance >= BigDecimal.ZERO) { "잔액은 0보다 작을 수 없습니다." }
+    }
+}

--- a/apps/commerce-api/src/main/kotlin/com/loopers/domain/point/Point.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/domain/point/Point.kt
@@ -20,4 +20,10 @@ class Point(userId: String, balance: BigDecimal = BigDecimal.ZERO) : BaseEntity(
     init {
         require(balance >= BigDecimal.ZERO) { "잔액은 0보다 작을 수 없습니다." }
     }
+
+    fun charge(amount: BigDecimal) {
+        require(amount > BigDecimal.ZERO) { "0 이하의 정수로 포인트를 충전할 수 없습니다." }
+
+        balance += amount
+    }
 }

--- a/apps/commerce-api/src/main/kotlin/com/loopers/domain/point/PointCommand.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/domain/point/PointCommand.kt
@@ -1,0 +1,12 @@
+package com.loopers.domain.point
+
+import java.math.BigDecimal
+
+object PointCommand {
+
+    data class Charge(val userId: String, val amount: BigDecimal) {
+        init {
+            require(userId.isNotBlank()) { "User ID cannot be blank." }
+        }
+    }
+}

--- a/apps/commerce-api/src/main/kotlin/com/loopers/domain/point/PointRepository.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/domain/point/PointRepository.kt
@@ -1,0 +1,8 @@
+package com.loopers.domain.point
+
+interface PointRepository {
+
+    fun find(userId: String): Point?
+
+    fun save(point: Point)
+}

--- a/apps/commerce-api/src/main/kotlin/com/loopers/domain/point/PointService.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/domain/point/PointService.kt
@@ -8,4 +8,18 @@ class PointService(private val pointRepository: PointRepository) {
 
     @Transactional(readOnly = true)
     fun find(userId: String): Point? = pointRepository.find(userId)
+
+    @Transactional
+    fun charge(command: PointCommand.Charge): Point {
+        val point = (
+                pointRepository.find(command.userId)
+                    ?: Point(userId = command.userId)
+                )
+
+        point.charge(command.amount)
+
+        pointRepository.save(point)
+
+        return point
+    }
 }

--- a/apps/commerce-api/src/main/kotlin/com/loopers/domain/point/PointService.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/domain/point/PointService.kt
@@ -1,0 +1,11 @@
+package com.loopers.domain.point
+
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class PointService(private val pointRepository: PointRepository) {
+
+    @Transactional(readOnly = true)
+    fun find(userId: String): Point? = pointRepository.find(userId)
+}

--- a/apps/commerce-api/src/main/kotlin/com/loopers/domain/user/Gender.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/domain/user/Gender.kt
@@ -1,0 +1,6 @@
+package com.loopers.domain.user
+
+enum class Gender {
+    M,
+    F,
+}

--- a/apps/commerce-api/src/main/kotlin/com/loopers/domain/user/User.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/domain/user/User.kt
@@ -1,0 +1,82 @@
+package com.loopers.domain.user
+
+import com.loopers.domain.BaseEntity
+import com.loopers.support.error.CoreException
+import com.loopers.support.error.ErrorType.BAD_REQUEST
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType.STRING
+import jakarta.persistence.Enumerated
+import jakarta.persistence.Table
+import java.time.LocalDate
+
+@Entity
+@Table(name = "member")
+class User(userId: String, email: String, birthdate: LocalDate, gender: Gender) : BaseEntity() {
+
+    @Column(name = "user_id", nullable = false)
+    val userId = userId
+
+    @Column(name = "email", nullable = false)
+    var email: String = email
+        private set
+
+    @Column(name = "birthdate", nullable = false)
+    var birthdate: LocalDate = birthdate
+        private set
+
+    @Enumerated(STRING)
+    @Column(name = "gender", nullable = false)
+    var gender: Gender = gender
+        private set
+
+    companion object {
+        operator fun invoke(
+            userId: String,
+            email: String,
+            birthdate: String,
+            gender: Gender,
+        ): User {
+            validateUserId(userId)
+            validateEmail(email)
+            validateBirthdate(birthdate)
+
+            return User(
+                userId = userId,
+                email = email,
+                birthdate = LocalDate.parse(birthdate),
+                gender = gender,
+            )
+        }
+
+        private val ID_PATTERN = Regex("^[a-zA-Z0-9]{1,10}$")
+        private val EMAIL_PATTERN = Regex("^[A-Za-z0-9._%+-]+@([A-Za-z0-9]+(-[A-Za-z0-9]+)*\\.)+[A-Za-z]{2,}$")
+        private val BIRTHDATE_PATTERN = Regex("^\\d{4}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])$")
+
+        private fun validateUserId(userId: String) {
+            require(ID_PATTERN.matches(userId)) {
+                throw CoreException(BAD_REQUEST, "아이디는 영문 및 숫자 10자 이내여야 합니다.")
+            }
+        }
+
+        private fun validateEmail(email: String) {
+            require(EMAIL_PATTERN.matches(email)) {
+                throw CoreException(BAD_REQUEST, "이메일 형식이 올바르지 않습니다.")
+            }
+        }
+
+        private fun validateBirthdate(birthdate: String) {
+            require(BIRTHDATE_PATTERN.matches(birthdate)) {
+                throw CoreException(BAD_REQUEST, "생년월일 형식이 올바르지 않습니다.")
+            }
+
+            val parsedDate = runCatching {
+                LocalDate.parse(birthdate)
+            }.getOrElse { throw CoreException(BAD_REQUEST, "생년월일 형식이 올바르지 않습니다.") }
+
+            require(parsedDate.isBefore(LocalDate.now())) {
+                throw CoreException(BAD_REQUEST, "생년월일은 오늘 이전 날짜여야 합니다.")
+            }
+        }
+    }
+}

--- a/apps/commerce-api/src/main/kotlin/com/loopers/domain/user/UserCommand.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/domain/user/UserCommand.kt
@@ -1,0 +1,12 @@
+package com.loopers.domain.user
+
+class UserCommand {
+
+    data class Create(val userId: String, val email: String, val birthdate: String, val gender: Gender) {
+        init {
+            require(userId.isNotBlank()) { "User ID cannot be blank." }
+            require(email.isNotBlank()) { "Email cannot be blank." }
+            require(birthdate.isNotBlank()) { "Birthdate cannot be blank." }
+        }
+    }
+}

--- a/apps/commerce-api/src/main/kotlin/com/loopers/domain/user/UserRepository.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/domain/user/UserRepository.kt
@@ -1,0 +1,8 @@
+package com.loopers.domain.user
+
+interface UserRepository {
+
+    fun save(user: User)
+
+    fun find(userId: String): User?
+}

--- a/apps/commerce-api/src/main/kotlin/com/loopers/domain/user/UserService.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/domain/user/UserService.kt
@@ -1,0 +1,23 @@
+package com.loopers.domain.user
+
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class UserService(private val userRepository: UserRepository) {
+
+    @Transactional
+    fun create(command: UserCommand.Create): User {
+        val user = User(
+            userId = command.userId,
+            email = command.email,
+            birthdate = command.birthdate,
+            gender = command.gender,
+        )
+        userRepository.save(user)
+        return user
+    }
+
+    @Transactional(readOnly = true)
+    fun find(userId: String): User? = userRepository.find(userId)
+}

--- a/apps/commerce-api/src/main/kotlin/com/loopers/infrastructure/point/PointCoreRepository.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/infrastructure/point/PointCoreRepository.kt
@@ -1,0 +1,15 @@
+package com.loopers.infrastructure.point
+
+import com.loopers.domain.point.Point
+import com.loopers.domain.point.PointRepository
+import org.springframework.stereotype.Component
+
+@Component
+class PointCoreRepository(private val pointJpaRepository: PointJpaRepository) : PointRepository {
+
+    override fun find(userId: String): Point? = pointJpaRepository.findByUserId(userId)
+
+    override fun save(point: Point) {
+        pointJpaRepository.save(point)
+    }
+}

--- a/apps/commerce-api/src/main/kotlin/com/loopers/infrastructure/point/PointJpaRepository.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/infrastructure/point/PointJpaRepository.kt
@@ -1,0 +1,9 @@
+package com.loopers.infrastructure.point
+
+import com.loopers.domain.point.Point
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface PointJpaRepository : JpaRepository<Point, Long> {
+
+    fun findByUserId(userId: String): Point?
+}

--- a/apps/commerce-api/src/main/kotlin/com/loopers/infrastructure/user/UserCoreRepository.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/infrastructure/user/UserCoreRepository.kt
@@ -1,0 +1,15 @@
+package com.loopers.infrastructure.user
+
+import com.loopers.domain.user.User
+import com.loopers.domain.user.UserRepository
+import org.springframework.stereotype.Component
+
+@Component
+class UserCoreRepository(private val userJpaRepository: UserJpaRepository) : UserRepository {
+
+    override fun save(user: User) {
+        userJpaRepository.save(user)
+    }
+
+    override fun find(userId: String): User? = userJpaRepository.findByUserId(userId)
+}

--- a/apps/commerce-api/src/main/kotlin/com/loopers/infrastructure/user/UserJpaRepository.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/infrastructure/user/UserJpaRepository.kt
@@ -1,0 +1,9 @@
+package com.loopers.infrastructure.user
+
+import com.loopers.domain.user.User
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface UserJpaRepository : JpaRepository<User, Long> {
+
+    fun findByUserId(userId: String): User?
+}

--- a/apps/commerce-api/src/main/kotlin/com/loopers/interfaces/api/ApiControllerAdvice.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/interfaces/api/ApiControllerAdvice.kt
@@ -8,16 +8,13 @@ import com.loopers.support.error.ErrorType
 import org.slf4j.LoggerFactory
 import org.springframework.http.ResponseEntity
 import org.springframework.http.converter.HttpMessageNotReadableException
+import org.springframework.web.bind.MissingRequestHeaderException
 import org.springframework.web.bind.MissingServletRequestParameterException
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.RestControllerAdvice
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException
 import org.springframework.web.server.ServerWebInputException
 import org.springframework.web.servlet.resource.NoResourceFoundException
-import kotlin.collections.joinToString
-import kotlin.jvm.java
-import kotlin.text.isNotEmpty
-import kotlin.text.toRegex
 
 @RestControllerAdvice
 class ApiControllerAdvice {
@@ -100,9 +97,15 @@ class ApiControllerAdvice {
     }
 
     @ExceptionHandler
-    fun handleNotFound(e: NoResourceFoundException): ResponseEntity<ApiResponse<*>> {
-        return failureResponse(errorType = ErrorType.NOT_FOUND)
+    fun handleBadRequest(e: MissingRequestHeaderException): ResponseEntity<ApiResponse<*>> {
+        val headerName = e.headerName
+        return failureResponse(errorType = ErrorType.BAD_REQUEST, errorMessage = "필수 요청 헤더 \'$headerName\'가 누락되었습니다.")
     }
+
+    @ExceptionHandler
+    fun handleNotFound(
+        e: NoResourceFoundException,
+    ): ResponseEntity<ApiResponse<*>> = failureResponse(errorType = ErrorType.NOT_FOUND)
 
     @ExceptionHandler
     fun handle(e: Throwable): ResponseEntity<ApiResponse<*>> {

--- a/apps/commerce-api/src/main/kotlin/com/loopers/interfaces/api/point/PointV1ApiSpec.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/interfaces/api/point/PointV1ApiSpec.kt
@@ -4,6 +4,9 @@ import com.loopers.interfaces.api.ApiResponse
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.Parameter
 import io.swagger.v3.oas.annotations.enums.ParameterIn
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.parameters.RequestBody
 import io.swagger.v3.oas.annotations.tags.Tag
 
 @Tag(name = "Point V1 API", description = "포인트 API 입니다.")
@@ -21,5 +24,30 @@ interface PointV1ApiSpec {
             `in` = ParameterIn.HEADER,
         )
         userId: String,
+    ): ApiResponse<PointV1Dto.Response.PointResponse>
+
+    @Operation(
+        summary = "포인트 충전",
+        description = "포인트를 충전에 성공할 경우, 충전된 보유 총량을 응답으로 반환합니다.",
+    )
+    fun chargePoints(
+        @Parameter(
+            name = "X-USER-ID",
+            description = "회원가입 때 가입한 ID 입니다.",
+            required = true,
+            `in` = ParameterIn.HEADER,
+        )
+        userId: String,
+
+        @RequestBody(
+            description = "포인트 충전 파라미터",
+            required = true,
+            content = [
+                Content(
+                    schema = Schema(PointV1Dto.Request.Charge::class),
+                ),
+            ],
+        )
+        request: PointV1Dto.Request.Charge,
     ): ApiResponse<PointV1Dto.Response.PointResponse>
 }

--- a/apps/commerce-api/src/main/kotlin/com/loopers/interfaces/api/point/PointV1ApiSpec.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/interfaces/api/point/PointV1ApiSpec.kt
@@ -1,0 +1,25 @@
+package com.loopers.interfaces.api.point
+
+import com.loopers.interfaces.api.ApiResponse
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.enums.ParameterIn
+import io.swagger.v3.oas.annotations.tags.Tag
+
+@Tag(name = "Point V1 API", description = "포인트 API 입니다.")
+interface PointV1ApiSpec {
+
+    @Operation(
+        summary = "포인트 정보 조회",
+        description = "포인트 조회에 성공할 경우, 보유 포인트를 응답으로 반환합니다.",
+    )
+    fun myPoints(
+        @Parameter(
+            name = "X-USER-ID",
+            description = "회원가입 때 가입한 ID 입니다.",
+            required = true,
+            `in` = ParameterIn.HEADER,
+        )
+        userId: String,
+    ): ApiResponse<PointV1Dto.Response.PointResponse>
+}

--- a/apps/commerce-api/src/main/kotlin/com/loopers/interfaces/api/point/PointV1Controller.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/interfaces/api/point/PointV1Controller.kt
@@ -1,0 +1,20 @@
+package com.loopers.interfaces.api.point
+
+import com.loopers.application.point.PointFacade
+import com.loopers.interfaces.api.ApiResponse
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestHeader
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/v1/points")
+class PointV1Controller(private val pointFacade: PointFacade) : PointV1ApiSpec {
+
+    @GetMapping
+    override fun myPoints(
+        @RequestHeader("X-USER-ID", required = true) userId: String,
+    ): ApiResponse<PointV1Dto.Response.PointResponse> = pointFacade.myPoints(userId)
+        .let { PointV1Dto.Response.PointResponse.from(it) }
+        .let { ApiResponse.success(it) }
+}

--- a/apps/commerce-api/src/main/kotlin/com/loopers/interfaces/api/point/PointV1Controller.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/interfaces/api/point/PointV1Controller.kt
@@ -2,7 +2,10 @@ package com.loopers.interfaces.api.point
 
 import com.loopers.application.point.PointFacade
 import com.loopers.interfaces.api.ApiResponse
+import jakarta.validation.Valid
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestHeader
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
@@ -15,6 +18,14 @@ class PointV1Controller(private val pointFacade: PointFacade) : PointV1ApiSpec {
     override fun myPoints(
         @RequestHeader("X-USER-ID", required = true) userId: String,
     ): ApiResponse<PointV1Dto.Response.PointResponse> = pointFacade.myPoints(userId)
+        .let { PointV1Dto.Response.PointResponse.from(it) }
+        .let { ApiResponse.success(it) }
+
+    @PostMapping("/charge")
+    override fun chargePoints(
+        @RequestHeader("X-USER-ID", required = true) userId: String,
+        @Valid @RequestBody request: PointV1Dto.Request.Charge,
+    ): ApiResponse<PointV1Dto.Response.PointResponse> = pointFacade.charge(request.toCommand(userId))
         .let { PointV1Dto.Response.PointResponse.from(it) }
         .let { ApiResponse.success(it) }
 }

--- a/apps/commerce-api/src/main/kotlin/com/loopers/interfaces/api/point/PointV1Dto.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/interfaces/api/point/PointV1Dto.kt
@@ -1,0 +1,19 @@
+package com.loopers.interfaces.api.point
+
+import com.loopers.application.point.PointInfo
+import java.math.BigDecimal
+
+object PointV1Dto {
+
+    class Response {
+
+        data class PointResponse(val balance: BigDecimal) {
+            companion object {
+                fun from(pointInfo: PointInfo): PointResponse =
+                    PointResponse(
+                        balance = pointInfo.balance,
+                    )
+            }
+        }
+    }
+}

--- a/apps/commerce-api/src/main/kotlin/com/loopers/interfaces/api/point/PointV1Dto.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/interfaces/api/point/PointV1Dto.kt
@@ -1,9 +1,28 @@
 package com.loopers.interfaces.api.point
 
 import com.loopers.application.point.PointInfo
+import com.loopers.domain.point.PointCommand
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.DecimalMin
+import jakarta.validation.constraints.NotNull
 import java.math.BigDecimal
 
 object PointV1Dto {
+
+    class Request {
+
+        data class Charge(
+            @Schema(description = "충전 금액", example = "1000")
+            @field:NotNull
+            @field:DecimalMin(value = "1", message = "충전 금액은 0 보다 커야 합니다.")
+            val amount: BigDecimal,
+        ) {
+            fun toCommand(userId: String) = PointCommand.Charge(
+                userId = userId,
+                amount = amount,
+            )
+        }
+    }
 
     class Response {
 

--- a/apps/commerce-api/src/main/kotlin/com/loopers/interfaces/api/user/UserV1ApiSpec.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/interfaces/api/user/UserV1ApiSpec.kt
@@ -1,0 +1,29 @@
+package com.loopers.interfaces.api.user
+
+import com.loopers.interfaces.api.ApiResponse
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.parameters.RequestBody
+import io.swagger.v3.oas.annotations.tags.Tag
+
+@Tag(name = "User V1 API", description = "사용자 API 입니다.")
+interface UserV1ApiSpec {
+
+    @Operation(
+        summary = "회원가입",
+        description = "회원 가입이 성공할 경우, 생성된 유저 정보를 응답으로 반환합니다.",
+    )
+    fun signup(
+        @RequestBody(
+            description = "회원가입 파라미터",
+            required = true,
+            content = [
+                Content(
+                    schema = Schema(UserV1Dto.Request.Signup::class),
+                ),
+            ],
+        )
+        request: UserV1Dto.Request.Signup,
+    ): ApiResponse<UserV1Dto.Response.UserResponse>
+}

--- a/apps/commerce-api/src/main/kotlin/com/loopers/interfaces/api/user/UserV1ApiSpec.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/interfaces/api/user/UserV1ApiSpec.kt
@@ -2,10 +2,13 @@ package com.loopers.interfaces.api.user
 
 import com.loopers.interfaces.api.ApiResponse
 import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.enums.ParameterIn
 import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.parameters.RequestBody
 import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.web.bind.annotation.RequestHeader
 
 @Tag(name = "User V1 API", description = "사용자 API 입니다.")
 interface UserV1ApiSpec {
@@ -25,5 +28,19 @@ interface UserV1ApiSpec {
             ],
         )
         request: UserV1Dto.Request.Signup,
+    ): ApiResponse<UserV1Dto.Response.UserResponse>
+
+    @Operation(
+        summary = "내 정보 조회",
+        description = "내 정보 조회에 성공할 경우, 해당하는 유저 정보를 응답으로 반환합니다.",
+    )
+    fun me(
+        @Parameter(
+            name = "X-USER-ID",
+            description = "회원가입 때 가입한 ID 입니다.",
+            required = true,
+            `in` = ParameterIn.HEADER,
+        )
+        @RequestHeader("X-USER-ID") userId: String,
     ): ApiResponse<UserV1Dto.Response.UserResponse>
 }

--- a/apps/commerce-api/src/main/kotlin/com/loopers/interfaces/api/user/UserV1Controller.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/interfaces/api/user/UserV1Controller.kt
@@ -4,8 +4,10 @@ import com.loopers.application.user.UserFacade
 import com.loopers.interfaces.api.ApiResponse
 import jakarta.validation.Valid
 import org.springframework.http.HttpStatus.CREATED
+import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestHeader
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
@@ -19,6 +21,13 @@ class UserV1Controller(private val userFacade: UserFacade) : UserV1ApiSpec {
     override fun signup(
         @Valid @RequestBody request: UserV1Dto.Request.Signup,
     ): ApiResponse<UserV1Dto.Response.UserResponse> = userFacade.signup(request.toCommand())
+        .let { UserV1Dto.Response.UserResponse.from(it) }
+        .let { ApiResponse.success(it) }
+
+    @GetMapping("/me")
+    override fun me(
+        @RequestHeader("X-USER-ID", required = true) userId: String,
+    ): ApiResponse<UserV1Dto.Response.UserResponse> = userFacade.me(userId)
         .let { UserV1Dto.Response.UserResponse.from(it) }
         .let { ApiResponse.success(it) }
 }

--- a/apps/commerce-api/src/main/kotlin/com/loopers/interfaces/api/user/UserV1Controller.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/interfaces/api/user/UserV1Controller.kt
@@ -1,0 +1,24 @@
+package com.loopers.interfaces.api.user
+
+import com.loopers.application.user.UserFacade
+import com.loopers.interfaces.api.ApiResponse
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus.CREATED
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/v1/users")
+class UserV1Controller(private val userFacade: UserFacade) : UserV1ApiSpec {
+
+    @PostMapping
+    @ResponseStatus(CREATED)
+    override fun signup(
+        @Valid @RequestBody request: UserV1Dto.Request.Signup,
+    ): ApiResponse<UserV1Dto.Response.UserResponse> = userFacade.signup(request.toCommand())
+        .let { UserV1Dto.Response.UserResponse.from(it) }
+        .let { ApiResponse.success(it) }
+}

--- a/apps/commerce-api/src/main/kotlin/com/loopers/interfaces/api/user/UserV1Dto.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/interfaces/api/user/UserV1Dto.kt
@@ -1,0 +1,52 @@
+package com.loopers.interfaces.api.user
+
+import com.loopers.application.user.UserInfo
+import com.loopers.domain.user.Gender
+import com.loopers.domain.user.UserCommand
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.NotNull
+
+object UserV1Dto {
+
+    class Request {
+        data class Signup(
+            @Schema(description = "아이디", example = "wjsyuwls")
+            @field:NotNull
+            val userId: String,
+
+            @Schema(description = "이메일", example = "wjsyuwls@gmail.com")
+            @field:NotNull
+            val email: String,
+
+            @Schema(description = "생년월일", example = "2000-01-01")
+            @field:NotNull
+            val birthdate: String,
+
+            @Schema(description = "성별 (M: 남성, F: 여성)", example = "M")
+            @field:NotNull
+            val gender: Gender,
+        ) {
+            fun toCommand(): UserCommand.Create =
+                UserCommand.Create(
+                    userId = userId,
+                    email = email,
+                    birthdate = birthdate,
+                    gender = gender,
+                )
+        }
+    }
+
+    class Response {
+        data class UserResponse(val userId: String, val email: String, val birthdate: String, val gender: Gender) {
+            companion object {
+                fun from(userInfo: UserInfo): UserResponse =
+                    UserResponse(
+                        userId = userInfo.userId,
+                        email = userInfo.email,
+                        birthdate = userInfo.birthdate.toString(),
+                        gender = userInfo.gender,
+                    )
+            }
+        }
+    }
+}

--- a/apps/commerce-api/src/test/kotlin/com/loopers/application/point/PointFacadeIntegrationTest.kt
+++ b/apps/commerce-api/src/test/kotlin/com/loopers/application/point/PointFacadeIntegrationTest.kt
@@ -1,0 +1,99 @@
+package com.loopers.application.point
+
+import com.loopers.domain.point.Point
+import com.loopers.domain.point.PointRepository
+import com.loopers.domain.user.Gender.M
+import com.loopers.domain.user.User
+import com.loopers.domain.user.UserRepository
+import com.loopers.support.error.CoreException
+import com.loopers.support.error.ErrorType.NOT_FOUND
+import com.loopers.utils.DatabaseCleanUp
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertAll
+import org.junit.jupiter.api.assertThrows
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import java.math.BigDecimal
+
+@SpringBootTest
+class PointFacadeIntegrationTest @Autowired constructor(
+    private val pointFacade: PointFacade,
+    private val pointRepository: PointRepository,
+    private val userRepository: UserRepository,
+    private val databaseCleanUp: DatabaseCleanUp,
+) {
+
+    @AfterEach
+    fun tearDown() {
+        databaseCleanUp.truncateAllTables()
+    }
+
+    @Nested
+    inner class `포인트를 조회할 때, ` {
+
+        @Test
+        fun `사용자가 존재하지 않으면, NOT_FOUND 예외가 발생한다`() {
+            // given
+            val userId = "wjsyuwls"
+
+            // when
+            val result = assertThrows<CoreException> {
+                pointFacade.myPoints(userId)
+            }
+
+            // then
+            assertAll(
+                { assertThat(result.errorType).isEqualTo(NOT_FOUND) },
+                { assertThat(result.message).isEqualTo("해당 사용자를 찾을 수 없습니다.") },
+            )
+        }
+
+        @Test
+        fun `포인트 정보가 없는 사용자를 조회하면, 0 포인트를 반환한다`() {
+            // given
+            val userId = "wjsyuwls"
+            val email = "wjsyuwls@gmail.com"
+            val birthdate = "2000-01-01"
+            val gender = M
+
+            userRepository.save(User(userId, email, birthdate, gender))
+
+            // when
+            val result = pointFacade.myPoints(userId)
+
+            // then
+            assertAll(
+                { assertThat(result).isNotNull() },
+                { assertThat(result.userId).isEqualTo(userId) },
+                { assertThat(result.balance).isEqualTo(BigDecimal.ZERO) },
+            )
+        }
+
+        @Test
+        fun `잔액이 정수일 경우, 소수점 이하를 생략하여 반환한다`() {
+            // given
+            val userId = "wjsyuwls"
+            val email = "wjsyuwls@gmail.com"
+            val birthdate = "2000-01-01"
+            val gender = M
+
+            userRepository.save(User(userId, email, birthdate, gender))
+
+            val balance = BigDecimal(10_000L)
+            pointRepository.save(Point(userId, balance))
+
+            // when
+            val result = pointFacade.myPoints(userId)
+
+            // then
+            assertAll(
+                { assertThat(result).isNotNull() },
+                { assertThat(result.userId).isEqualTo(userId) },
+                { assertThat(result.balance.toPlainString()).isEqualTo(balance.toPlainString()) },
+            )
+        }
+    }
+}

--- a/apps/commerce-api/src/test/kotlin/com/loopers/application/point/PointFacadeIntegrationTest.kt
+++ b/apps/commerce-api/src/test/kotlin/com/loopers/application/point/PointFacadeIntegrationTest.kt
@@ -1,6 +1,7 @@
 package com.loopers.application.point
 
 import com.loopers.domain.point.Point
+import com.loopers.domain.point.PointCommand
 import com.loopers.domain.point.PointRepository
 import com.loopers.domain.user.Gender.M
 import com.loopers.domain.user.User
@@ -95,5 +96,24 @@ class PointFacadeIntegrationTest @Autowired constructor(
                 { assertThat(result.balance.toPlainString()).isEqualTo(balance.toPlainString()) },
             )
         }
+    }
+
+    @Test
+    fun `포인트를 충전할 때, 사용자가 존재하지 않으면, NOT_FOUND 예외가 발생한다`() {
+        // given
+        val userId = "wjsyuwls"
+        val amount = BigDecimal.ONE
+        val command = PointCommand.Charge(userId, amount)
+
+        // when
+        val result = assertThrows<CoreException> {
+            pointFacade.charge(command)
+        }
+
+        // then
+        assertAll(
+            { assertThat(result.errorType).isEqualTo(NOT_FOUND) },
+            { assertThat(result.message).isEqualTo("해당 사용자를 찾을 수 없습니다.") },
+        )
     }
 }

--- a/apps/commerce-api/src/test/kotlin/com/loopers/application/user/UserFacadeIntegrationTest.kt
+++ b/apps/commerce-api/src/test/kotlin/com/loopers/application/user/UserFacadeIntegrationTest.kt
@@ -6,6 +6,7 @@ import com.loopers.domain.user.UserCommand
 import com.loopers.domain.user.UserRepository
 import com.loopers.support.error.CoreException
 import com.loopers.support.error.ErrorType.CONFLICT
+import com.loopers.support.error.ErrorType.NOT_FOUND
 import com.loopers.utils.DatabaseCleanUp
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
@@ -55,6 +56,23 @@ class UserFacadeIntegrationTest @Autowired constructor(
         assertAll(
             { assertThat(result.errorType).isEqualTo(CONFLICT) },
             { assertThat(result.message).isEqualTo("동일한 ID로 이미 가입된 계정이 존재합니다.") },
+        )
+    }
+
+    @Test
+    fun `사용자 정보를 조회할 때, 존재하지 않는 사용자 ID로 조회하면, NOT_FOUND 예외가 발생한다`() {
+        // given
+        val userId = "wjsyuwls"
+
+        // when
+        val result = assertThrows<CoreException> {
+            userFacade.me(userId)
+        }
+
+        // then
+        assertAll(
+            { assertThat(result.errorType).isEqualTo(NOT_FOUND) },
+            { assertThat(result.message).isEqualTo("해당 사용자를 찾을 수 없습니다.") },
         )
     }
 }

--- a/apps/commerce-api/src/test/kotlin/com/loopers/application/user/UserFacadeIntegrationTest.kt
+++ b/apps/commerce-api/src/test/kotlin/com/loopers/application/user/UserFacadeIntegrationTest.kt
@@ -1,0 +1,60 @@
+package com.loopers.application.user
+
+import com.loopers.domain.user.Gender.M
+import com.loopers.domain.user.User
+import com.loopers.domain.user.UserCommand
+import com.loopers.domain.user.UserRepository
+import com.loopers.support.error.CoreException
+import com.loopers.support.error.ErrorType.CONFLICT
+import com.loopers.utils.DatabaseCleanUp
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertAll
+import org.junit.jupiter.api.assertThrows
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+
+@SpringBootTest
+class UserFacadeIntegrationTest @Autowired constructor(
+    private val userRepository: UserRepository,
+    private val userFacade: UserFacade,
+    private val databaseCleanUp: DatabaseCleanUp,
+) {
+
+    @AfterEach
+    fun tearDown() {
+        databaseCleanUp.truncateAllTables()
+    }
+
+    @Test
+    fun `회원가입을 할 때,  이미 가입된 ID로 회원가입을 시도하면, CONFLICT 예외가 발생한다`() {
+        // given
+        val userId = "wjsyuwls"
+        val email = "wjsyuwls@gmail.com"
+        val birthdate = "2000-01-01"
+        val gender = M
+
+        userRepository.save(
+            User(
+                userId = userId,
+                email = email,
+                birthdate = birthdate,
+                gender = gender,
+            ),
+        )
+
+        val command = UserCommand.Create(userId, email, birthdate, gender)
+
+        // when
+        val result = assertThrows<CoreException> {
+            userFacade.signup(command)
+        }
+
+        // then
+        assertAll(
+            { assertThat(result.errorType).isEqualTo(CONFLICT) },
+            { assertThat(result.message).isEqualTo("동일한 ID로 이미 가입된 계정이 존재합니다.") },
+        )
+    }
+}

--- a/apps/commerce-api/src/test/kotlin/com/loopers/domain/point/PointServiceIntegrationTest.kt
+++ b/apps/commerce-api/src/test/kotlin/com/loopers/domain/point/PointServiceIntegrationTest.kt
@@ -1,0 +1,59 @@
+package com.loopers.domain.point
+
+import com.loopers.utils.DatabaseCleanUp
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertAll
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import java.math.BigDecimal
+
+@SpringBootTest
+class PointServiceIntegrationTest @Autowired constructor(
+    private val pointRepository: PointRepository,
+    private val pointService: PointService,
+    private val databaseCleanUp: DatabaseCleanUp,
+) {
+
+    @AfterEach
+    fun tearDown() {
+        databaseCleanUp.truncateAllTables()
+    }
+
+    @Nested
+    inner class `포인트를 조회할 때, ` {
+
+        @Test
+        fun `포인트 정보가 존재하지 않는 사용자 ID로 조회하면, null을 반환한다`() {
+            // given
+            val userId = "wjsyuwls"
+
+            // when
+            val result = pointService.find(userId)
+
+            // then
+            assertThat(result).isNull()
+        }
+
+        @Test
+        fun `포인트 정보가 존재하는 사용자 ID로 조회하면, 보유 포인트 정보를 반환한다`() {
+            // given
+            val userId = "wjsyuwls"
+            val balance = BigDecimal(10_000L)
+
+            pointRepository.save(Point(userId, balance))
+
+            // when
+            val result = pointService.find(userId)
+
+            // then
+            assertAll(
+                { assertThat(result).isNotNull() },
+                { assertThat(result!!.userId).isEqualTo(userId) },
+                { assertThat(result!!.balance.compareTo(balance)).isEqualTo(0) },
+            )
+        }
+    }
+}

--- a/apps/commerce-api/src/test/kotlin/com/loopers/domain/point/PointServiceIntegrationTest.kt
+++ b/apps/commerce-api/src/test/kotlin/com/loopers/domain/point/PointServiceIntegrationTest.kt
@@ -56,4 +56,92 @@ class PointServiceIntegrationTest @Autowired constructor(
             )
         }
     }
+
+    @Nested
+    inner class `포인트를 충전할 때, ` {
+
+        @Test
+        fun `포인트 정보가 존재하지 않는 사용자 ID로 충전하면, 포인트 정보를 생성하고 잔액을 충전 금액으로 초기화하여 저장한다`() {
+            // given
+            val userId = "wjsyuwls"
+            val amount = BigDecimal(10_000L)
+            val command = PointCommand.Charge(userId, amount)
+
+            // when
+            pointService.charge(command)
+
+            // then
+            val result = pointRepository.find(userId)
+
+            assertAll(
+                { assertThat(result).isNotNull() },
+                { assertThat(result!!.userId).isEqualTo(userId) },
+                { assertThat(result!!.balance.compareTo(amount)).isEqualTo(0) },
+            )
+        }
+
+        @Test
+        fun `포인트 정보가 존재하지 않는 사용자 ID로 충전하면, 포인트 정보를 생성하고 잔액을 충전 금액으로 초기화하여 반환한다`() {
+            // given
+            val userId = "wjsyuwls"
+            val amount = BigDecimal(10_000L)
+            val command = PointCommand.Charge(userId, amount)
+
+            // when
+            val result = pointService.charge(command)
+
+            // then
+            assertAll(
+                { assertThat(result).isNotNull() },
+                { assertThat(result.userId).isEqualTo(userId) },
+                { assertThat(result.balance).isEqualTo(amount) },
+            )
+        }
+
+        @Test
+        fun `포인트 정보가 존재하는 사용자 ID로 충전하면, 포인트를 충전하고 합산된 잔액을 저장한다`() {
+            // given
+            val userId = "wjsyuwls"
+            val balance = BigDecimal(5_000L)
+
+            pointRepository.save(Point(userId, balance))
+
+            val amount = BigDecimal(10_000L)
+            val command = PointCommand.Charge(userId, amount)
+
+            // when
+            pointService.charge(command)
+
+            // then
+            val result = pointRepository.find(userId)
+
+            assertAll(
+                { assertThat(result).isNotNull() },
+                { assertThat(result!!.userId).isEqualTo(userId) },
+                { assertThat(result!!.balance.compareTo(balance + amount)).isEqualTo(0) },
+            )
+        }
+
+        @Test
+        fun `포인트 정보가 존재하는 사용자 ID로 충전하면, 포인트를 충전하고 합산된 잔액을 반환한다`() {
+            // given
+            val userId = "wjsyuwls"
+            val balance = BigDecimal(5_000L)
+
+            pointRepository.save(Point(userId, balance))
+
+            val amount = BigDecimal(10_000L)
+            val command = PointCommand.Charge(userId, amount)
+
+            // when
+            val result = pointService.charge(command)
+
+            // then
+            assertAll(
+                { assertThat(result).isNotNull() },
+                { assertThat(result.userId).isEqualTo(userId) },
+                { assertThat(result.balance.compareTo(balance + amount)).isEqualTo(0) },
+            )
+        }
+    }
 }

--- a/apps/commerce-api/src/test/kotlin/com/loopers/domain/point/PointTest.kt
+++ b/apps/commerce-api/src/test/kotlin/com/loopers/domain/point/PointTest.kt
@@ -1,0 +1,49 @@
+package com.loopers.domain.point
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertAll
+import org.junit.jupiter.api.assertThrows
+import java.math.BigDecimal
+
+class PointTest {
+
+    @Nested
+    inner class `포인트 엔티티를 생성할 때, ` {
+
+        @Test
+        fun `잔액이 음수이면, ILLEGAL_ARGUMENT 예외가 발생한다`() {
+            // given
+            val userId = "wjsyuwls"
+            val balance = BigDecimal(-1L)
+
+            // when
+            val result = assertThrows<IllegalArgumentException> {
+                Point(userId, balance)
+            }
+
+            // then
+            assertAll(
+                { assertThat(result.javaClass).isEqualTo(IllegalArgumentException::class.java) },
+                { assertThat(result.message).isEqualTo("잔액은 0보다 작을 수 없습니다.") },
+            )
+        }
+
+        @Test
+        fun `잔액이 0 이상이면, 정상적으로 생성된다`() {
+            // given
+            val userId = "wjsyuwls"
+            val balance = BigDecimal.ONE
+
+            // when
+            val result = Point(userId, balance)
+
+            // then
+            assertAll(
+                { assertThat(result.userId).isEqualTo(userId) },
+                { assertThat(result.balance).isEqualTo(balance) },
+            )
+        }
+    }
+}

--- a/apps/commerce-api/src/test/kotlin/com/loopers/domain/point/PointTest.kt
+++ b/apps/commerce-api/src/test/kotlin/com/loopers/domain/point/PointTest.kt
@@ -46,4 +46,43 @@ class PointTest {
             )
         }
     }
+
+    @Nested
+    inner class `포인트를 충전할 때,` {
+
+        @Test
+        fun `0 이하의 포인트를 충전하면, ILLEGAL_ARGUMENT 예외가 발생한다`() {
+            // given
+            val userId = "wjsyuwls"
+            val balance = BigDecimal(10_000L)
+            val point = Point(userId, balance)
+            val amount = BigDecimal.ZERO
+
+            // when
+            val result = assertThrows<IllegalArgumentException> {
+                point.charge(amount)
+            }
+
+            // then
+            assertAll(
+                { assertThat(result.javaClass).isEqualTo(IllegalArgumentException::class.java) },
+                { assertThat(result.message).isEqualTo("0 이하의 정수로 포인트를 충전할 수 없습니다.") },
+            )
+        }
+
+        @Test
+        fun `0 보다 큰 포인트를 충전하면, 해당 포인트의 잔액이 정상적으로 증가한다`() {
+            // given
+            val userId = "wjsyuwls"
+            val balance = BigDecimal(10_000L)
+            val point = Point(userId, balance)
+            val amount = BigDecimal.ONE
+
+            // when
+            point.charge(amount)
+
+            // then
+            assertThat(point.balance).isEqualTo(balance + amount)
+        }
+    }
 }

--- a/apps/commerce-api/src/test/kotlin/com/loopers/domain/user/UserServiceIntegrationTest.kt
+++ b/apps/commerce-api/src/test/kotlin/com/loopers/domain/user/UserServiceIntegrationTest.kt
@@ -1,0 +1,128 @@
+package com.loopers.domain.user
+
+import com.loopers.domain.user.Gender.M
+import com.loopers.utils.DatabaseCleanUp
+import com.ninjasquad.springmockk.SpykBean
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertAll
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import java.time.LocalDate
+
+@SpringBootTest
+class UserServiceIntegrationTest @Autowired constructor(
+    @SpykBean
+    private val userRepository: UserRepository,
+    private val userService: UserService,
+    private val databaseCleanUp: DatabaseCleanUp,
+) {
+
+    @AfterEach
+    fun tearDown() {
+        databaseCleanUp.truncateAllTables()
+    }
+
+    @Nested
+    inner class `사용자를 생성 할 때, ` {
+
+        @Test
+        fun `성공적으로 생성되면, 생성된 사용자 정보를 저장한다`() {
+            // given
+            val userId = "wjsyuwls"
+            val email = "wjsyuwls@google.com"
+            val birthdate = "2000-01-01"
+            val gender = M
+            val command = UserCommand.Create(userId, email, birthdate, gender)
+
+            // when
+            userService.create(command)
+
+            // then
+            val result = userService.find(userId)
+
+            assertAll(
+                { assertThat(result).isNotNull() },
+                { assertThat(result!!.userId).isEqualTo(userId) },
+                { assertThat(result!!.email).isEqualTo(email) },
+                { assertThat(result!!.birthdate).isEqualTo(birthdate) },
+                { assertThat(result!!.gender).isEqualTo(gender) },
+            )
+        }
+
+        @Test
+        fun `성공적으로 생성되면, 생성된 사용자 정보를 저장하고 반환한다`() {
+            // given
+            val userId = "wjsyuwls"
+            val email = "wjsyuwls@gmail.com"
+            val birthdate = "2000-01-01"
+            val gender = M
+            val command = UserCommand.Create(userId, email, birthdate, gender)
+
+            // when
+            val result = userService.create(command)
+
+            // then
+            assertAll(
+                { assertThat(result).isNotNull() },
+                { assertThat(result.userId).isEqualTo(userId) },
+                { assertThat(result.email).isEqualTo(email) },
+                { assertThat(result.birthdate).isEqualTo(birthdate) },
+                { assertThat(result.gender).isEqualTo(gender) },
+            )
+
+            verify(exactly = 1) {
+                userRepository.save(
+                    match {
+                        it.userId == userId &&
+                                it.email == email &&
+                                it.birthdate == LocalDate.parse(birthdate) &&
+                                it.gender == gender
+                    },
+                )
+            }
+        }
+    }
+
+    @Nested
+    inner class `사용자 정보를 조회할 때, ` {
+
+        @Test
+        fun `존재하지 않는 사용자 ID로 조회하면, null을 반환한다`() {
+            // given
+            val userId = "wjsyuwls"
+
+            // when
+            val result = userService.find(userId)
+
+            // then
+            assertThat(result).isNull()
+        }
+
+        @Test
+        fun `존재하는 사용자 ID로 조회하면, 해당 사용자 정보를 반환한다`() {
+            // given
+            val userId = "wjsyuwls"
+            val email = "wjsyuwls@gmail.com"
+            val birthdate = "2000-01-01"
+            val gender = M
+
+            userRepository.save(User(userId, email, birthdate, gender))
+
+            // when
+            val result = userService.find(userId)
+
+            // then
+            assertAll(
+                { assertThat(result).isNotNull() },
+                { assertThat(result!!.userId).isEqualTo(userId) },
+                { assertThat(result!!.email).isEqualTo(email) },
+                { assertThat(result!!.birthdate).isEqualTo(birthdate) },
+                { assertThat(result!!.gender).isEqualTo(gender) },
+            )
+        }
+    }
+}

--- a/apps/commerce-api/src/test/kotlin/com/loopers/domain/user/UserTest.kt
+++ b/apps/commerce-api/src/test/kotlin/com/loopers/domain/user/UserTest.kt
@@ -1,0 +1,163 @@
+package com.loopers.domain.user
+
+import com.loopers.domain.user.Gender.M
+import com.loopers.support.error.CoreException
+import com.loopers.support.error.ErrorType.BAD_REQUEST
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertAll
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+import java.time.LocalDate
+
+class UserTest {
+
+    @Nested
+    inner class `사용자 엔티티를 생성할 때, ` {
+
+        @ParameterizedTest
+        @ValueSource(
+            strings = [
+                "", // 빈 문자열
+                "wjsyuwls 1234", // 공백 포함
+                "wjsyuwls1234!", // 특수문자 포함
+                "전유진", // 한글 포함
+                "wjsyuwls_1234", // 언더스코어 포함
+                "wjsyuwls123", // 10자 초과
+            ],
+        )
+        fun `ID가 유효하지 않은 형식이면, BAD_REQUEST 예외가 발생한다`(invalidId: String) {
+            // given
+            val email = "wjsyuwls@google.com"
+            val birthdate = "2000-01-01"
+            val gender = M
+
+            // when
+            val result = assertThrows<CoreException> {
+                User(
+                    userId = invalidId,
+                    email = email,
+                    birthdate = birthdate,
+                    gender = gender,
+                )
+            }
+
+            // then
+            assertAll(
+                { assertThat(result.errorType).isEqualTo(BAD_REQUEST) },
+                { assertThat(result.message).isEqualTo("아이디는 영문 및 숫자 10자 이내여야 합니다.") },
+            )
+        }
+
+        @ParameterizedTest
+        @ValueSource(
+            strings = [
+                "", // 빈 문자열
+                "wjsyuwls@google.com ", // 후행 공백
+                " wjsyuwls@google.com", // 선행 공백
+                "wjsyuwlsgoogle.com", // @ 없음
+                "@google.com", // 아이디 없음
+                "wjsyuwls@", // 도메인 없음
+                "wjsyuwls@.com", // 도메인 없음
+                "wjsyuwls@google", // TLD 없음
+                "wjsyuwls@google.c", // TLD 1자
+                "wjsyuwls@google..com", // 연속된 점
+                "wjsyuwls@google,com", // 잘못된 구분자
+                "wjsyuwls@-google.com", // 도메인 시작 하이픈
+                "wjsyuwls@google-.com", // 도메인 끝 하이픈
+                "wjsyuwls@google_.com", // 도메인 언더스코어
+            ],
+        )
+        fun `이메일이 유효하지 않은 형식이면, BAD_REQUEST 예외가 발생한다`(invalidEmail: String) {
+            // given
+            val userId = "wjsyuwls12"
+            val birthdate = "2000-01-01"
+            val gender = M
+
+            // when
+            val result = assertThrows<CoreException> {
+                User(
+                    userId = userId,
+                    email = invalidEmail,
+                    birthdate = birthdate,
+                    gender = gender,
+                )
+            }
+
+            // then
+            assertAll(
+                { assertThat(result.errorType).isEqualTo(BAD_REQUEST) },
+                { assertThat(result.message).isEqualTo("이메일 형식이 올바르지 않습니다.") },
+            )
+        }
+
+        @ParameterizedTest
+        @ValueSource(
+            strings = [
+                "", // 빈 문자열
+                "20000101", // 구분자 없음
+                "2000/01/01", // 슬래시 구분자
+                "20-01-01", // 연도 2자리
+                "2000-1-1", // 월, 일 한 자리
+                "2000-001-01", // 월 3자리
+                "2000-01-011", // 일 3자리
+                "2000-13-01", // 존재하지 않는 월
+                "2000-12-32", // 존재하지 않는 일
+                "2000-00-10", // 0월
+                "abcd-ef-gh", // 문자 포함
+                " 2000-01-01", // 앞에 공백
+                "2000-01-01 ", // 뒤에 공백
+                "2000.01.01", // 점 구분자
+            ],
+        )
+        fun `생년월일이 유효하지 않은 형식이면, BAD_REQUEST 예외가 발생한다`(invalidBirthdate: String) {
+            // given
+            val userId = "wjsyuwls12"
+            val email = "wjsyuwls@google.com"
+            val gender = M
+
+            // when
+            val result = assertThrows<CoreException> {
+                User(
+                    userId = userId,
+                    email = email,
+                    birthdate = invalidBirthdate,
+                    gender = gender,
+                )
+            }
+
+            // then
+            assertAll(
+                { assertThat(result.errorType).isEqualTo(BAD_REQUEST) },
+                { assertThat(result.message).isEqualTo("생년월일 형식이 올바르지 않습니다.") },
+            )
+        }
+
+        @Test
+        fun `생년월일이 현재 날짜 이후라면, BAD_REQUEST 예외가 발생한다`() {
+            // given
+            val userId = "wjsyuwls12"
+            val email = "wjsyuwls@google.com"
+            val invalidBirthdate = LocalDate.now().plusDays(1).toString()
+            val gender = M
+
+            // when
+            val result = assertThrows<CoreException> {
+                User(
+                    userId = userId,
+                    email = email,
+                    birthdate = invalidBirthdate,
+                    gender = gender,
+                )
+            }
+
+            // then
+            assertAll(
+                { assertThat(result.errorType).isEqualTo(BAD_REQUEST) },
+                { assertThat(result.message).isEqualTo("생년월일은 오늘 이전 날짜여야 합니다.") },
+            )
+        }
+    }
+}

--- a/apps/commerce-api/src/test/kotlin/com/loopers/interfaces/api/point/PointV1ApiE2ETest.kt
+++ b/apps/commerce-api/src/test/kotlin/com/loopers/interfaces/api/point/PointV1ApiE2ETest.kt
@@ -1,0 +1,88 @@
+package com.loopers.interfaces.api.point
+
+import com.loopers.domain.point.Point
+import com.loopers.domain.point.PointRepository
+import com.loopers.domain.user.Gender.M
+import com.loopers.domain.user.User
+import com.loopers.domain.user.UserRepository
+import com.loopers.interfaces.api.ApiResponse
+import com.loopers.utils.DatabaseCleanUp
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertAll
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.web.client.TestRestTemplate
+import org.springframework.core.ParameterizedTypeReference
+import org.springframework.http.HttpEntity
+import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpMethod.GET
+import org.springframework.http.HttpStatus.BAD_REQUEST
+import org.springframework.http.HttpStatus.OK
+import java.math.BigDecimal
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class PointV1ApiE2ETest @Autowired constructor(
+    private val testRestTemplate: TestRestTemplate,
+    private val pointRepository: PointRepository,
+    private val userRepository: UserRepository,
+    private val databaseCleanUp: DatabaseCleanUp,
+) {
+
+    @AfterEach
+    fun tearDown() {
+        databaseCleanUp.truncateAllTables()
+    }
+
+    @Nested
+    inner class `포인트 정보를 조회할 때, ` {
+
+        var requestUrl = "/api/v1/points"
+
+        @Test
+        fun `X-USER-ID 헤더가 없으면, 400 Bad Request 응답을 반환한다`() {
+            // given
+
+            // when
+            val responseType = object : ParameterizedTypeReference<ApiResponse<PointV1Dto.Response.PointResponse>>() {}
+            val response = testRestTemplate.exchange(requestUrl, GET, HttpEntity<Any>(Unit), responseType)
+
+            // then
+            assertAll(
+                { assertThat(response.statusCode).isEqualTo(BAD_REQUEST) },
+                { assertThat(response.body!!.meta.result).isEqualTo(ApiResponse.Metadata.Result.FAIL) },
+                { assertThat(response.body!!.meta.errorCode).isEqualTo(BAD_REQUEST.reasonPhrase) },
+                { assertThat(response.body!!.meta.message).isEqualTo("필수 요청 헤더 'X-USER-ID'가 누락되었습니다.") },
+            )
+        }
+
+        @Test
+        fun `포인트 조회에 성공할 경우, 보유 포인트를 응답으로 반환한다`() {
+            // given
+            val userId = "wjsyuwls"
+            val email = "wjsyuwls@gmail.com"
+            val birthdate = "2000-01-01"
+            val gender = M
+            userRepository.save(User(userId, email, birthdate, gender))
+
+            val balance = BigDecimal(10_000L)
+            pointRepository.save(Point(userId, balance))
+
+            val headers = HttpHeaders().apply { set("X-USER-ID", userId) }
+            val httpEntity = HttpEntity(null, headers)
+
+            // when
+            val responseType = object : ParameterizedTypeReference<ApiResponse<PointV1Dto.Response.PointResponse>>() {}
+            val response = testRestTemplate.exchange(requestUrl, GET, httpEntity, responseType)
+
+            // then
+            assertAll(
+                { assertThat(response.statusCode).isEqualTo(OK) },
+                { assertThat(response.body!!.meta.result).isEqualTo(ApiResponse.Metadata.Result.SUCCESS) },
+                { assertThat(response.body?.data?.balance).isEqualTo(balance) },
+            )
+        }
+    }
+}

--- a/apps/commerce-api/src/test/kotlin/com/loopers/interfaces/api/user/UserV1ApiE2ETest.kt
+++ b/apps/commerce-api/src/test/kotlin/com/loopers/interfaces/api/user/UserV1ApiE2ETest.kt
@@ -1,0 +1,149 @@
+package com.loopers.interfaces.api.user
+
+import com.loopers.domain.user.Gender.M
+import com.loopers.interfaces.api.ApiResponse
+import com.loopers.utils.DatabaseCleanUp
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertAll
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.web.client.TestRestTemplate
+import org.springframework.core.ParameterizedTypeReference
+import org.springframework.http.HttpEntity
+import org.springframework.http.HttpMethod.POST
+import org.springframework.http.HttpStatus.BAD_REQUEST
+import org.springframework.http.HttpStatus.CREATED
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class UserV1ApiE2ETest @Autowired constructor(
+    private val testRestTemplate: TestRestTemplate,
+    private val databaseCleanUp: DatabaseCleanUp,
+) {
+
+    @AfterEach
+    fun tearDown() {
+        databaseCleanUp.truncateAllTables()
+    }
+
+    @Nested
+    inner class `회원가입을 할 때, ` {
+
+        val requestUrl = "/api/v1/users"
+
+        @Test
+        fun `회원가입이 성공하면, 생성된 유저 정보를 응답으로 반환한다 `() {
+            // given
+            val request = UserV1Dto.Request.Signup(
+                userId = "wjsyuwls",
+                email = "wjsyuwls@gmail.com",
+                birthdate = "2000-01-01",
+                gender = M,
+            )
+
+            // when
+            val responseType = object : ParameterizedTypeReference<ApiResponse<UserV1Dto.Response.UserResponse>>() {}
+            val response = testRestTemplate.exchange(requestUrl, POST, HttpEntity<Any>(request), responseType)
+
+            // then
+            assertAll(
+                { assertThat(response.statusCode).isEqualTo(CREATED) },
+                { assertThat(response.body?.meta?.result).isEqualTo(ApiResponse.Metadata.Result.SUCCESS) },
+                { assertThat(response.body?.data?.userId).isEqualTo(request.userId) },
+                { assertThat(response.body?.data?.email).isEqualTo(request.email) },
+                { assertThat(response.body?.data?.birthdate).isEqualTo(request.birthdate) },
+                { assertThat(response.body?.data?.gender).isEqualTo(request.gender) },
+            )
+        }
+
+        @Test
+        fun `성별 정보가 누락되면, 400 Bad Request 응답을 반환한다`() {
+            // given
+            val request = mapOf(
+                "userId" to "wjsyuwls",
+                "email" to "wjsyuwls@gmail.com",
+                "birthdate" to "2000-01-01",
+            )
+
+            // when
+            val responseType = object : ParameterizedTypeReference<ApiResponse<UserV1Dto.Response.UserResponse>>() {}
+            val response = testRestTemplate.exchange(requestUrl, POST, HttpEntity<Any>(request), responseType)
+
+            // then
+            assertAll(
+                { assertThat(response.statusCode).isEqualTo(BAD_REQUEST) },
+                { assertThat(response?.body?.meta?.result).isEqualTo(ApiResponse.Metadata.Result.FAIL) },
+                { assertThat(response?.body?.meta?.errorCode).isEqualTo(BAD_REQUEST.reasonPhrase) },
+                { assertThat(response?.body?.meta?.message).isEqualTo("필수 필드 'gender'이(가) 누락되었습니다.") },
+            )
+        }
+
+        @Test
+        fun `사용자 아이디 정보가 누락되면, 400 Bad Request 응답을 반환한다`() {
+            // given
+            val request = mapOf(
+                "email" to "wjsyuwls@gmail.com",
+                "birthdate" to "2000-01-01",
+                "gender" to "M",
+            )
+
+            // when
+            val responseType = object : ParameterizedTypeReference<ApiResponse<UserV1Dto.Response.UserResponse>>() {}
+            val response = testRestTemplate.exchange(requestUrl, POST, HttpEntity<Any>(request), responseType)
+
+            // then
+            assertAll(
+                { assertThat(response.statusCode).isEqualTo(BAD_REQUEST) },
+                { assertThat(response?.body?.meta?.result).isEqualTo(ApiResponse.Metadata.Result.FAIL) },
+                { assertThat(response?.body?.meta?.errorCode).isEqualTo(BAD_REQUEST.reasonPhrase) },
+                { assertThat(response?.body?.meta?.message).isEqualTo("필수 필드 'userId'이(가) 누락되었습니다.") },
+            )
+        }
+
+        @Test
+        fun `이메일 정보가 누락되면, 400 Bad Request 응답을 반환한다`() {
+            // given
+            val request = mapOf(
+                "userId" to "wjsyuwls",
+                "birthdate" to "2000-01-01",
+                "gender" to "M",
+            )
+
+            // when
+            val responseType = object : ParameterizedTypeReference<ApiResponse<UserV1Dto.Response.UserResponse>>() {}
+            val response = testRestTemplate.exchange(requestUrl, POST, HttpEntity<Any>(request), responseType)
+
+            // then
+            assertAll(
+                { assertThat(response.statusCode).isEqualTo(BAD_REQUEST) },
+                { assertThat(response?.body?.meta?.result).isEqualTo(ApiResponse.Metadata.Result.FAIL) },
+                { assertThat(response?.body?.meta?.errorCode).isEqualTo(BAD_REQUEST.reasonPhrase) },
+                { assertThat(response?.body?.meta?.message).isEqualTo("필수 필드 'email'이(가) 누락되었습니다.") },
+            )
+        }
+
+        @Test
+        fun `생년월일 정보가 누락되면, 400 Bad Request 응답을 반환한다`() {
+            // given
+            val request = mapOf(
+                "userId" to "wjsyuwls",
+                "email" to "wjsyuwls@gmail.com",
+                "gender" to "M",
+            )
+
+            // when
+            val responseType = object : ParameterizedTypeReference<ApiResponse<UserV1Dto.Response.UserResponse>>() {}
+            val response = testRestTemplate.exchange(requestUrl, POST, HttpEntity<Any>(request), responseType)
+
+            // then
+            assertAll(
+                { assertThat(response.statusCode).isEqualTo(BAD_REQUEST) },
+                { assertThat(response?.body?.meta?.result).isEqualTo(ApiResponse.Metadata.Result.FAIL) },
+                { assertThat(response?.body?.meta?.errorCode).isEqualTo(BAD_REQUEST.reasonPhrase) },
+                { assertThat(response?.body?.meta?.message).isEqualTo("필수 필드 'birthdate'이(가) 누락되었습니다.") },
+            )
+        }
+    }
+}

--- a/http/commerce-api/point-v1.api.http
+++ b/http/commerce-api/point-v1.api.http
@@ -1,0 +1,3 @@
+### 포인트 조회
+GET {{commerce-api}}/api/v1/points
+X-USER-ID: wjsyuwls

--- a/http/commerce-api/point-v1.api.http
+++ b/http/commerce-api/point-v1.api.http
@@ -1,3 +1,12 @@
 ### 포인트 조회
 GET {{commerce-api}}/api/v1/points
 X-USER-ID: wjsyuwls
+
+### 포인트 충전
+POST {{commerce-api}}/api/v1/points/charge
+Content-Type: application/json
+X-USER-ID: wjsyuwls
+
+{
+  "amount": "1000"
+}

--- a/http/commerce-api/user-v1.api.http
+++ b/http/commerce-api/user-v1.api.http
@@ -1,0 +1,10 @@
+### 회원가입
+POST {{commerce-api}}/api/v1/users
+Content-Type: application/json
+
+{
+  "userId": "wjsyuwls",
+  "email": "wjsyuwls@gmail.com",
+  "birthdate": "2000-01-01",
+  "gender": "M"
+}

--- a/http/commerce-api/user-v1.api.http
+++ b/http/commerce-api/user-v1.api.http
@@ -8,3 +8,7 @@ Content-Type: application/json
   "birthdate": "2000-01-01",
   "gender": "M"
 }
+
+### 내 정보 조회
+GET {{commerce-api}}/api/v1/users/me
+X-USER-ID: wjsyuwls


### PR DESCRIPTION
## 📌 Summary
회원가입, 내 정보 조회, 포인트 조회, 포인트 충전 기능에 대한 단위, 통합, E2E 테스트를 작성하며 각 기능의 핵심 비즈니스 로직부터 외부 연동 및 사용자 시나리오까지 다양한 관점에서 검증했습니다.

## 💬 Review Points

이번 과제에서 회원 및 포인트 도메인 서비스의 테스트 전략에 대해 고민이 있었습니다.

**테스트 범위의 중복**: 처음에는 도메인 서비스에 대해 테스트 더블을 활용한 단위 테스트를 먼저 시도했습니다. 하지만 이후 과제에서 요구된 통합 테스트를 작성하는 과정에서, 도메인 서비스의 테스트 내용이 단위 테스트와 통합 테스트 간에 상당 부분 겹치는 현상이 발생했습니다. 이로 인해 두 테스트 레벨의 명확한 구분이 어려웠습니다.

**도메인 서비스 테스트의 적합성**: 도메인 서비스는 Repository와의 의존성을 가집니다. Repository는 외부 API처럼 완전히 분리된 외부 시스템이 아니라 내부 시스템의 한 부분이라고 생각했습니다. 따라서, Repository를 테스트 대역으로 대체하는 것보다 `@SpringBootTest`를 활용하여 실제 DB 연동을 포함한 통합 테스트를 작성하는 것이 더 적합하다고 판단했습니다.

결과적으로, 도메인 서비스의 비즈니스 로직 검증은 `@SpringBootTest`를 활용하는 방향으로 진행했습니다.

## ✅ Checklist

### 회원가입

**🧱 단위 테스트**

- [x]  ID 가 `영문 및 숫자 10자 이내` 형식에 맞지 않으면, User 객체 생성에 실패한다.
- [x]  이메일이 `xx@yy.zz` 형식에 맞지 않으면, User 객체 생성에 실패한다.
- [x]  생년월일이 `yyyy-MM-dd` 형식에 맞지 않으면, User 객체 생성에 실패한다.

**🔗 통합 테스트**

- [x]  회원 가입시 User 저장이 수행된다. ( spy 검증 )
- [x]  이미 가입된 ID 로 회원가입 시도 시, 실패한다.

**🌐 E2E 테스트**

- [x]  회원 가입이 성공할 경우, 생성된 유저 정보를 응답으로 반환한다.
- [x]  회원 가입 시에 성별이 없을 경우, `400 Bad Request` 응답을 반환한다.

### 내 정보 조회

**🔗 통합 테스트**

- [x]  해당 ID 의 회원이 존재할 경우, 회원 정보가 반환된다.
- [x]  해당 ID 의 회원이 존재하지 않을 경우, null 이 반환된다.

**🌐 E2E 테스트**

- [x]  내 정보 조회에 성공할 경우, 해당하는 유저 정보를 응답으로 반환한다.
- [x]  존재하지 않는 ID 로 조회할 경우, `404 Not Found` 응답을 반환한다.

### 포인트 조회

**🔗 통합 테스트**

- [x]  해당 ID 의 회원이 존재할 경우, 보유 포인트가 반환된다.
- [x]  해당 ID 의 회원이 존재하지 않을 경우, null 이 반환된다.

**🌐 E2E 테스트**

- [x]  포인트 조회에 성공할 경우, 보유 포인트를 응답으로 반환한다.
- [x]  `X-USER-ID` 헤더가 없을 경우, `400 Bad Request` 응답을 반환한다.

### 포인트 충전

**🧱 단위 테스트**

- [x]  0 이하의 정수로 포인트를 충전 시 실패한다.

**🔗 통합 테스트**

- [x]  존재하지 않는 유저 ID 로 충전을 시도한 경우, 실패한다.

**🌐 E2E 테스트**

- [x]  존재하는 유저가 1000원을 충전할 경우, 충전된 보유 총량을 응답으로 반환한다.
- [x]  존재하지 않는 유저로 요청할 경우, `404 Not Found` 응답을 반환한다.