### PR TITLE
[round-6] PG 연동, 서킷 브레이커 적용

### DIFF
--- a/apps/commerce-api/build.gradle.kts
+++ b/apps/commerce-api/build.gradle.kts
@@ -14,9 +14,14 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("org.springframework.boot:spring-boot-starter-actuator")
     implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:${project.properties["springDocOpenApiVersion"]}")
+    implementation("org.springframework.cloud:spring-cloud-starter-openfeign")
 
     // querydsl
     kapt("com.querydsl:querydsl-apt::jakarta")
+
+    // resilience4j
+    implementation("io.github.resilience4j:resilience4j-spring-boot3")
+    implementation("org.springframework.boot:spring-boot-starter-aop")
 
     // test-fixtures
     testImplementation(testFixtures(project(":modules:jpa")))

--- a/apps/commerce-api/src/main/kotlin/com/loopers/CommerceApiApplication.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/CommerceApiApplication.kt
@@ -4,8 +4,10 @@ import jakarta.annotation.PostConstruct
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan
 import org.springframework.boot.runApplication
+import org.springframework.cloud.openfeign.EnableFeignClients
 import java.util.TimeZone
 
+@EnableFeignClients
 @ConfigurationPropertiesScan
 @SpringBootApplication
 class CommerceApiApplication {

--- a/apps/commerce-api/src/main/kotlin/com/loopers/application/order/OrderInput.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/application/order/OrderInput.kt
@@ -1,13 +1,22 @@
 package com.loopers.application.order
 
 import com.loopers.domain.order.OrderCommand
+import com.loopers.domain.payment.model.CardType
+import com.loopers.domain.payment.PaymentMethod
 import org.springframework.data.domain.Pageable
 
 class OrderInput private constructor() {
 
-    data class Order(val loginId: String, val orderItems: List<OrderItem>, val couponId: Long? = null)
-
-    data class OrderItem(val productId: Long, val quantity: Int)
+    data class Order(
+        val loginId: String,
+        val orderItems: List<OrderItem>,
+        val couponId: Long? = null,
+        val paymentMethod: PaymentMethod,
+        val cardType: CardType? = null,
+        val cardNo: String? = null,
+    ) {
+        data class OrderItem(val productId: Long, val quantity: Int)
+    }
 
     data class GetOrders(val loginId: String, val pageable: Pageable) {
         fun toCommand(userId: Long): OrderCommand.GetOrders =

--- a/apps/commerce-api/src/main/kotlin/com/loopers/application/payment/PaymentFacade.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/application/payment/PaymentFacade.kt
@@ -1,0 +1,48 @@
+package com.loopers.application.payment
+
+import com.loopers.domain.order.OrderService
+import com.loopers.domain.payment.PaymentCommand
+import com.loopers.domain.payment.PaymentService
+import com.loopers.domain.stock.StockCommand
+import com.loopers.domain.stock.StockService
+import com.loopers.infrastructure.support.transaction.TransactionSynchronizationExecutor
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+
+@Component
+class PaymentFacade(
+    private val paymentService: PaymentService,
+    private val orderService: OrderService,
+    private val stockService: StockService,
+    private val transactionSynchronizationExecutor: TransactionSynchronizationExecutor,
+) {
+
+    @Transactional
+    fun complete(input: PaymentInput.Complete) {
+        paymentService.complete(
+            PaymentCommand.Complete(
+                orderCode = input.orderId,
+                transactionKey = input.transactionKey,
+                paidAt = input.paidAt,
+            ),
+        )
+
+        transactionSynchronizationExecutor.afterCommit {
+            val order = orderService.getOrder(input.orderId)
+            try {
+                order.orderLines.forEach { orderLine ->
+                    stockService.deduct(
+                        StockCommand.Deduct(
+                            productId = orderLine.productId,
+                            quantity = orderLine.quantity,
+                        ),
+                    )
+                }
+            } catch (e: Exception) {
+                // 주문 완료 후 재고 차감 중 오류 발생 시, 결제 취소
+                // 쿠폰 사용 취소 등 추가 작업이 필요할 수 있음
+                throw e
+            }
+        }
+    }
+}

--- a/apps/commerce-api/src/main/kotlin/com/loopers/application/payment/PaymentInput.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/application/payment/PaymentInput.kt
@@ -1,0 +1,18 @@
+package com.loopers.application.payment
+
+import com.loopers.domain.payment.model.CardType
+import com.loopers.domain.payment.model.TransactionStatus
+
+object PaymentInput {
+
+    data class Complete(
+        val transactionKey: String,
+        val orderId: String,
+        val cardType: CardType,
+        val cardNo: String,
+        val amount: Long,
+        val status: TransactionStatus,
+        val reason: String?,
+        val paidAt: String,
+    )
+}

--- a/apps/commerce-api/src/main/kotlin/com/loopers/domain/coupon/CouponService.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/domain/coupon/CouponService.kt
@@ -1,5 +1,6 @@
 package com.loopers.domain.coupon
 
+import com.loopers.domain.coupon.entity.Coupon
 import com.loopers.domain.coupon.entity.IssuedCoupon
 import com.loopers.support.error.CoreException
 import com.loopers.support.error.ErrorType.NOT_FOUND
@@ -25,6 +26,10 @@ class CouponService(private val couponRepository: CouponRepository) {
         )
         couponRepository.saveIssuedCoupon(issuedCoupon)
     }
+
+    fun findCouponIfIssuedToUser(couponId: Long, userId: Long): Coupon? =
+        couponRepository.findIssuedCouponBy(couponId, userId)
+            ?.let { couponRepository.findById(couponId) }
 
     @Transactional
     fun use(command: CouponCommand.Use) {

--- a/apps/commerce-api/src/main/kotlin/com/loopers/domain/order/OrderCommand.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/domain/order/OrderCommand.kt
@@ -1,12 +1,12 @@
 package com.loopers.domain.order
 
+import com.loopers.domain.coupon.entity.Coupon
 import com.loopers.domain.order.entity.OrderLine
 import org.springframework.data.domain.Pageable
-import java.math.BigDecimal
 
 class OrderCommand private constructor() {
 
-    data class PlaceOrder(val userId: Long, val orderLines: List<OrderLine>, val paymentAmount: BigDecimal)
+    data class PlaceOrder(val userId: Long, val orderLines: List<OrderLine>, val coupon: Coupon? = null)
 
     data class GetOrders(val userId: Long, val pageable: Pageable)
 }

--- a/apps/commerce-api/src/main/kotlin/com/loopers/domain/order/OrderRepository.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/domain/order/OrderRepository.kt
@@ -10,4 +10,6 @@ interface OrderRepository {
     fun findById(id: Long): Order?
 
     fun findOrders(command: OrderCommand.GetOrders): Page<Order>
+
+    fun findByOrderCode(orderCode: String): Order?
 }

--- a/apps/commerce-api/src/main/kotlin/com/loopers/domain/order/OrderService.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/domain/order/OrderService.kt
@@ -1,37 +1,35 @@
 package com.loopers.domain.order
 
-import com.loopers.domain.order.model.OrderStatus.PAYMENT_PENDING
 import com.loopers.domain.order.entity.Order
 import com.loopers.domain.order.model.OrderInfo
+import com.loopers.domain.order.model.OrderStatus.PENDING
 import com.loopers.support.error.CoreException
 import com.loopers.support.error.ErrorType.NOT_FOUND
+import com.loopers.support.uuid.UUIDGenerator
 import org.springframework.data.domain.Page
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
 @Transactional(readOnly = true)
 @Service
-class OrderService(private val orderRepository: OrderRepository) {
+class OrderService(private val orderRepository: OrderRepository, private val uuidGenerator: UUIDGenerator) {
 
     @Transactional
     fun placeOrder(command: OrderCommand.PlaceOrder): OrderInfo {
+        val orderCode = uuidGenerator.generate()
+
         val order = Order(
+            orderCode = orderCode,
             userId = command.userId,
             orderLines = command.orderLines,
-            status = PAYMENT_PENDING,
-            paymentAmount = command.paymentAmount,
+            status = PENDING,
         )
+
+        command.coupon?.calculateDiscountedAmount(order.totalPrice)
+            ?.let { order.changePaymentAmount(it) }
+
         orderRepository.save(order)
         return OrderInfo.from(order)
-    }
-
-    @Transactional
-    fun completePayment(orderId: Long) {
-        val order = orderRepository.findById(orderId)
-            ?: throw CoreException(NOT_FOUND, "주문을 찾을 수 없습니다. 주문 ID: $orderId")
-
-        order.completePayment()
-        orderRepository.save(order)
     }
 
     fun getOrders(command: OrderCommand.GetOrders): Page<OrderInfo> =
@@ -42,4 +40,9 @@ class OrderService(private val orderRepository: OrderRepository) {
         orderRepository.findById(orderId)
             ?.let { OrderInfo.from(it) }
             ?: throw CoreException(NOT_FOUND, "주문을 찾을 수 없습니다. 주문 ID: $orderId")
+
+    fun getOrder(orderCode: String): OrderInfo =
+        orderRepository.findByOrderCode(orderCode)
+            ?.let { OrderInfo.from(it) }
+            ?: throw CoreException(NOT_FOUND, "주문을 찾을 수 없습니다. 주문 코드: $orderCode")
 }

--- a/apps/commerce-api/src/main/kotlin/com/loopers/domain/order/model/OrderInfo.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/domain/order/model/OrderInfo.kt
@@ -5,6 +5,7 @@ import java.math.BigDecimal
 
 data class OrderInfo(
     val id: Long,
+    val orderCode: String,
     val userId: Long,
     val orderLines: List<OrderLineInfo>,
     val totalPrice: BigDecimal,
@@ -16,6 +17,7 @@ data class OrderInfo(
         fun from(order: Order): OrderInfo =
             OrderInfo(
                 id = order.id,
+                orderCode = order.orderCode,
                 userId = order.userId,
                 orderLines = order.orderLines.map { OrderLineInfo.from(it) },
                 totalPrice = order.totalPrice,

--- a/apps/commerce-api/src/main/kotlin/com/loopers/domain/order/model/OrderStatus.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/domain/order/model/OrderStatus.kt
@@ -1,6 +1,7 @@
 package com.loopers.domain.order.model
 
 enum class OrderStatus {
-    PAYMENT_PENDING,
-    PAYMENT_COMPLETED,
+    PENDING,
+    CANCELLED,
+    SHIPPED,
 }

--- a/apps/commerce-api/src/main/kotlin/com/loopers/domain/payment/CardPaymentProcessor.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/domain/payment/CardPaymentProcessor.kt
@@ -1,0 +1,42 @@
+package com.loopers.domain.payment
+
+import com.loopers.domain.payment.PaymentMethod.CARD
+import com.loopers.domain.payment.entity.Payment
+import com.loopers.domain.payment.model.PaymentStatus.PENDING
+import com.loopers.domain.payment.model.TransactionStatus.FAILED
+import com.loopers.infrastructure.support.transaction.TransactionSynchronizationExecutor
+import jakarta.transaction.Transactional
+import org.springframework.stereotype.Component
+
+@Component
+class CardPaymentProcessor(
+    private val paymentRepository: PaymentRepository,
+    private val transactionSynchronizationExecutor: TransactionSynchronizationExecutor,
+    private val paymentGateway: PaymentGateway,
+) : PaymentProcessor {
+
+    override fun paymentMethod(): PaymentMethod = CARD
+
+    @Transactional
+    override fun process(command: PaymentCommand.Pay) {
+        val payment = Payment(
+            userId = command.userId,
+            orderCode = command.orderCode,
+            amount = command.amount,
+            paymentMethod = command.paymentMethod,
+            cardType = command.cardType,
+            cardNo = command.cardNo,
+            status = PENDING,
+        )
+        paymentRepository.save(payment)
+
+        transactionSynchronizationExecutor.afterCommit {
+            val result = paymentGateway.requestPayment(command.userId.toString(), command)
+
+            if (result.status == FAILED) {
+                payment.failed()
+                paymentRepository.save(payment)
+            }
+        }
+    }
+}

--- a/apps/commerce-api/src/main/kotlin/com/loopers/domain/payment/PaymentCommand.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/domain/payment/PaymentCommand.kt
@@ -1,0 +1,47 @@
+package com.loopers.domain.payment
+
+import com.loopers.domain.payment.PaymentMethod.CARD
+import com.loopers.domain.payment.model.CardType
+import com.loopers.support.error.CoreException
+import com.loopers.support.error.ErrorType.BAD_REQUEST
+import java.math.BigDecimal
+
+object PaymentCommand {
+
+    data class Pay(
+        val userId: Long,
+        val orderCode: String,
+        val amount: BigDecimal,
+        val paymentMethod: PaymentMethod,
+        val cardType: CardType? = null,
+        val cardNo: String? = null,
+    ) {
+        init {
+            require(orderCode.isNotBlank()) {
+                throw CoreException(BAD_REQUEST, "주문 코드는 비어있을 수 없습니다.")
+            }
+            if (paymentMethod == CARD) {
+                require(cardType != null) {
+                    throw CoreException(BAD_REQUEST, "카드 결제 시 카드 타입을 지정해야 합니다.")
+                }
+                require(cardNo != null) {
+                    throw CoreException(BAD_REQUEST, "카드 결제 시 카드 번호를 지정해야 합니다.")
+                }
+            }
+        }
+    }
+
+    data class Complete(val orderCode: String, val transactionKey: String, val paidAt: String) {
+        init {
+            require(orderCode.isNotBlank()) {
+                throw CoreException(BAD_REQUEST, "주문 코드는 비어있을 수 없습니다.")
+            }
+            require(transactionKey.isNotBlank()) {
+                throw CoreException(BAD_REQUEST, "거래 키는 비어있을 수 없습니다.")
+            }
+            require(paidAt.isNotBlank()) {
+                throw CoreException(BAD_REQUEST, "결제 완료 시간은 비어있을 수 없습니다.")
+            }
+        }
+    }
+}

--- a/apps/commerce-api/src/main/kotlin/com/loopers/domain/payment/PaymentGateway.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/domain/payment/PaymentGateway.kt
@@ -1,0 +1,16 @@
+package com.loopers.domain.payment
+
+import com.loopers.domain.payment.model.PaymentGatewayInfo
+
+interface PaymentGateway {
+
+    fun requestPayment(
+        userId: String,
+        command: PaymentCommand.Pay,
+    ): PaymentGatewayInfo
+
+    fun getPayments(
+        userId: String,
+        orderId: String,
+    ): List<PaymentGatewayInfo>
+}

--- a/apps/commerce-api/src/main/kotlin/com/loopers/domain/payment/PaymentMethod.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/domain/payment/PaymentMethod.kt
@@ -1,0 +1,6 @@
+package com.loopers.domain.payment
+
+enum class PaymentMethod {
+    POINT,
+    CARD,
+}

--- a/apps/commerce-api/src/main/kotlin/com/loopers/domain/payment/PaymentProcessor.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/domain/payment/PaymentProcessor.kt
@@ -1,0 +1,8 @@
+package com.loopers.domain.payment
+
+interface PaymentProcessor {
+
+    fun paymentMethod(): PaymentMethod
+
+    fun process(command: PaymentCommand.Pay)
+}

--- a/apps/commerce-api/src/main/kotlin/com/loopers/domain/payment/PaymentRepository.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/domain/payment/PaymentRepository.kt
@@ -1,0 +1,12 @@
+package com.loopers.domain.payment
+
+import com.loopers.domain.payment.entity.Payment
+
+interface PaymentRepository {
+
+    fun save(payment: Payment): Payment
+
+    fun findByOrderCode(orderCode: String): Payment?
+
+    fun findAllByCompletedFalse(): List<Payment>
+}

--- a/apps/commerce-api/src/main/kotlin/com/loopers/domain/payment/PaymentService.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/domain/payment/PaymentService.kt
@@ -1,0 +1,44 @@
+package com.loopers.domain.payment
+
+import com.loopers.domain.payment.model.PaymentGatewayInfo
+import com.loopers.domain.payment.model.PaymentInfo
+import com.loopers.support.error.CoreException
+import com.loopers.support.error.ErrorType.BAD_REQUEST
+import com.loopers.support.error.ErrorType.NOT_FOUND
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Transactional(readOnly = true)
+@Service
+class PaymentService(
+    paymentProcessors: List<PaymentProcessor>,
+    private val paymentRepository: PaymentRepository,
+    private val paymentGateway: PaymentGateway,
+) {
+
+    private val paymentProcessorMap by lazy { paymentProcessors.associateBy { it.paymentMethod() } }
+
+    @Transactional
+    fun pay(command: PaymentCommand.Pay) {
+        val processor = paymentProcessorMap[command.paymentMethod]
+            ?: throw CoreException(BAD_REQUEST, "지원하지 않는 결제 수단입니다: ${command.paymentMethod}")
+
+        processor.process(command)
+    }
+
+    @Transactional
+    fun complete(command: PaymentCommand.Complete) {
+        val payment = paymentRepository.findByOrderCode(command.orderCode)
+            ?: throw CoreException(NOT_FOUND, "결제 정보를 찾을 수 없습니다. 주문 코드: ${command.orderCode}")
+
+        payment.complete(command.transactionKey, command.paidAt)
+        paymentRepository.save(payment)
+    }
+
+    fun getNotCompletedPayments(): List<PaymentInfo> =
+        paymentRepository.findAllByCompletedFalse()
+            .map { PaymentInfo.from(it) }
+
+    fun getPaymentByOrderCode(userId: String, orderCode: String): List<PaymentGatewayInfo> =
+        paymentGateway.getPayments(userId, orderCode)
+}

--- a/apps/commerce-api/src/main/kotlin/com/loopers/domain/payment/PointPaymentProcessor.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/domain/payment/PointPaymentProcessor.kt
@@ -1,0 +1,24 @@
+package com.loopers.domain.payment
+
+import com.loopers.domain.payment.PaymentMethod.POINT
+import com.loopers.domain.point.PointWalletRepository
+import com.loopers.domain.point.vo.Point
+import com.loopers.support.error.CoreException
+import com.loopers.support.error.ErrorType.NOT_FOUND
+import jakarta.transaction.Transactional
+import org.springframework.stereotype.Component
+
+@Component
+class PointPaymentProcessor(private val pointWalletRepository: PointWalletRepository) : PaymentProcessor {
+
+    override fun paymentMethod(): PaymentMethod = POINT
+
+    @Transactional
+    override fun process(command: PaymentCommand.Pay) {
+        val pointWallet = pointWalletRepository.findByUserIdWithLock(command.userId)
+            ?: throw CoreException(NOT_FOUND, "해당 사용자의 포인트 지갑을 찾을 수 없습니다.")
+
+        pointWallet.use(Point.of(command.amount))
+        pointWalletRepository.save(pointWallet)
+    }
+}

--- a/apps/commerce-api/src/main/kotlin/com/loopers/domain/payment/entity/Payment.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/domain/payment/entity/Payment.kt
@@ -1,0 +1,88 @@
+package com.loopers.domain.payment.entity
+
+import com.loopers.domain.BaseEntity
+import com.loopers.domain.payment.PaymentMethod
+import com.loopers.domain.payment.PaymentMethod.CARD
+import com.loopers.domain.payment.model.CardType
+import com.loopers.domain.payment.model.PaymentStatus
+import com.loopers.domain.payment.model.PaymentStatus.FAILED
+import com.loopers.domain.payment.model.PaymentStatus.SUCCESS
+import com.loopers.support.error.CoreException
+import com.loopers.support.error.ErrorType.BAD_REQUEST
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType.STRING
+import jakarta.persistence.Enumerated
+import jakarta.persistence.Table
+import java.math.BigDecimal
+
+@Entity
+@Table(name = "payment")
+class Payment(
+    userId: Long,
+    orderCode: String,
+    paymentMethod: PaymentMethod,
+    cardType: CardType?,
+    cardNo: String?,
+    amount: BigDecimal,
+    status: PaymentStatus,
+) : BaseEntity() {
+
+    val userId: Long = userId
+
+    val orderCode: String = orderCode
+
+    @Enumerated(STRING)
+    val paymentMethod: PaymentMethod = paymentMethod
+
+    @Enumerated(STRING)
+    val cardType: CardType? = cardType
+
+    val cardNo: String? = cardNo
+
+    val amount: BigDecimal = amount
+
+    @Enumerated(STRING)
+    var status: PaymentStatus = status
+        private set
+
+    var transactionKey: String? = null
+        private set
+
+    var paidAt: String? = null
+        private set
+
+    init {
+        require(amount > BigDecimal.ZERO) {
+            throw CoreException(BAD_REQUEST, "결제 금액은 0보다 커야 합니다.")
+        }
+        if (paymentMethod == CARD) {
+            require(cardType != null) {
+                throw CoreException(BAD_REQUEST, "카드 결제 시 카드 타입을 지정해야 합니다.")
+            }
+            require(cardNo != null) {
+                throw CoreException(BAD_REQUEST, "카드 결제 시 카드 번호를 지정해야 합니다.")
+            }
+        }
+    }
+
+    fun complete(transactionKey: String, paidAt: String) {
+        require(transactionKey.isNotBlank()) {
+            throw CoreException(BAD_REQUEST, "거래 키는 비어있을 수 없습니다.")
+        }
+        require(paidAt.isNotBlank()) {
+            throw CoreException(BAD_REQUEST, "결제 완료 시간은 비어있을 수 없습니다.")
+        }
+
+        this.status = SUCCESS
+        this.transactionKey = transactionKey
+        this.paidAt = paidAt
+    }
+
+    fun failed() {
+        if (status == SUCCESS) {
+            throw CoreException(BAD_REQUEST, "이미 완료된 결제는 실패 처리를 할 수 없습니다.")
+        }
+
+        this.status = FAILED
+    }
+}

--- a/apps/commerce-api/src/main/kotlin/com/loopers/domain/payment/model/CardType.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/domain/payment/model/CardType.kt
@@ -1,0 +1,7 @@
+package com.loopers.domain.payment.model
+
+enum class CardType {
+    SAMSUNG,
+    KB,
+    HYUNDAI,
+}

--- a/apps/commerce-api/src/main/kotlin/com/loopers/domain/payment/model/PaymentGatewayInfo.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/domain/payment/model/PaymentGatewayInfo.kt
@@ -1,0 +1,9 @@
+package com.loopers.domain.payment.model
+
+data class PaymentGatewayInfo(val transactionKey: String, val status: TransactionStatus, val reason: String?)
+
+enum class TransactionStatus {
+    PENDING,
+    SUCCESS,
+    FAILED,
+}

--- a/apps/commerce-api/src/main/kotlin/com/loopers/domain/payment/model/PaymentInfo.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/domain/payment/model/PaymentInfo.kt
@@ -1,0 +1,32 @@
+package com.loopers.domain.payment.model
+
+import com.loopers.domain.payment.PaymentMethod
+import com.loopers.domain.payment.entity.Payment
+import java.math.BigDecimal
+
+data class PaymentInfo(
+    val userId: Long,
+    val orderCode: String,
+    val paymentMethod: PaymentMethod,
+    val cardType: CardType?,
+    val cardNo: String?,
+    val amount: BigDecimal,
+    val status: PaymentStatus,
+    val transactionKey: String?,
+    val paidAt: String?,
+    ) {
+    companion object {
+        fun from(payment: Payment): PaymentInfo =
+            PaymentInfo(
+                userId = payment.userId,
+                orderCode = payment.orderCode,
+                paymentMethod = payment.paymentMethod,
+                cardType = payment.cardType,
+                cardNo = payment.cardNo,
+                amount = payment.amount,
+                status = payment.status,
+                transactionKey = payment.transactionKey,
+                paidAt = payment.paidAt,
+            )
+    }
+}

--- a/apps/commerce-api/src/main/kotlin/com/loopers/domain/payment/model/PaymentStatus.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/domain/payment/model/PaymentStatus.kt
@@ -1,0 +1,8 @@
+package com.loopers.domain.payment.model
+
+enum class PaymentStatus {
+
+    PENDING,
+    SUCCESS,
+    FAILED,
+}

--- a/apps/commerce-api/src/main/kotlin/com/loopers/domain/product/ProductService.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/domain/product/ProductService.kt
@@ -12,14 +12,10 @@ import org.springframework.transaction.annotation.Transactional
 class ProductService(private val productRepository: ProductRepository) {
 
     fun getProductOnSale(productId: Long): ProductInfo {
-        val product = (
-                productRepository.findById(productId)
-                    ?: throw CoreException(NOT_FOUND, "해당 상품을 찾을 수 없습니다.")
-                )
+        val product = productRepository.findById(productId)
+            ?: throw CoreException(NOT_FOUND, "해당 상품을 찾을 수 없습니다.")
 
-        if (product.isNotOnSale()) {
-            throw CoreException(NOT_FOUND, "해당 상품은 판매 중이 아닙니다.")
-        }
+        product.checkIsOnSale()
 
         return ProductInfo.from(product)
     }

--- a/apps/commerce-api/src/main/kotlin/com/loopers/infrastructure/order/OrderCoreRepository.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/infrastructure/order/OrderCoreRepository.kt
@@ -20,4 +20,6 @@ class OrderCoreRepository(
 
     override fun findOrders(command: OrderCommand.GetOrders): Page<Order> =
         customRepository.findOrders(command)
+
+    override fun findByOrderCode(orderCode: String): Order? = orderJpaRepository.findByOrderCode(orderCode)
 }

--- a/apps/commerce-api/src/main/kotlin/com/loopers/infrastructure/order/OrderJpaRepository.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/infrastructure/order/OrderJpaRepository.kt
@@ -6,4 +6,6 @@ import org.springframework.data.jpa.repository.JpaRepository
 interface OrderJpaRepository : JpaRepository<Order, Long> {
 
     fun findByUserId(userId: Long): List<Order>
+
+    fun findByOrderCode(orderCode: String): Order?
 }

--- a/apps/commerce-api/src/main/kotlin/com/loopers/infrastructure/payment/PaymentCoreRepository.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/infrastructure/payment/PaymentCoreRepository.kt
@@ -1,0 +1,16 @@
+package com.loopers.infrastructure.payment
+
+import com.loopers.domain.payment.PaymentRepository
+import com.loopers.domain.payment.entity.Payment
+import org.springframework.stereotype.Component
+
+@Component
+class PaymentCoreRepository(private val paymentJpaRepository: PaymentJpaRepository) : PaymentRepository {
+
+    override fun save(payment: Payment): Payment = paymentJpaRepository.save(payment)
+
+    override fun findByOrderCode(orderCode: String): Payment? = paymentJpaRepository.findByOrderCode(orderCode)
+
+    override fun findAllByCompletedFalse(): List<Payment> =
+        paymentJpaRepository.findAllByCompletedFalse()
+}

--- a/apps/commerce-api/src/main/kotlin/com/loopers/infrastructure/payment/PaymentJpaRepository.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/infrastructure/payment/PaymentJpaRepository.kt
@@ -1,0 +1,13 @@
+package com.loopers.infrastructure.payment
+
+import com.loopers.domain.payment.entity.Payment
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+
+interface PaymentJpaRepository : JpaRepository<Payment, Long> {
+
+    fun findByOrderCode(orderCode: String): Payment?
+
+    @Query("select p from Payment p where p.status != 'SUCCESS'")
+    fun findAllByCompletedFalse(): List<Payment>
+}

--- a/apps/commerce-api/src/main/kotlin/com/loopers/infrastructure/payment/PgDto.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/infrastructure/payment/PgDto.kt
@@ -1,0 +1,67 @@
+package com.loopers.infrastructure.payment
+
+import com.loopers.domain.payment.model.CardType
+import com.loopers.domain.payment.model.PaymentGatewayInfo
+import com.loopers.domain.payment.model.TransactionStatus
+
+object PgDto {
+
+    data class PaymentRequest(
+        val orderId: String,
+        val cardType: CardType,
+        val cardNo: String,
+        val amount: Long,
+        val callbackUrl: String,
+    )
+
+    data class PaymentResponse(val meta: Meta, val data: PaymentData) {
+        data class Meta(val result: String)
+        data class PaymentData(val transactionKey: String, val status: TransactionStatusDto, val reason: String?)
+
+        fun toPaymentGatewayInfo(): PaymentGatewayInfo =
+            PaymentGatewayInfo(
+                data.transactionKey,
+                data.status.toTransactionStatus(),
+                data.reason,
+            )
+
+        enum class TransactionStatusDto {
+            PENDING,
+            SUCCESS,
+            FAILED,
+            ;
+
+            fun toTransactionStatus(): TransactionStatus = when (this) {
+                PENDING -> TransactionStatus.PENDING
+                SUCCESS -> TransactionStatus.SUCCESS
+                FAILED -> TransactionStatus.FAILED
+            }
+        }
+    }
+
+    data class OrderResponse(val meta: Meta, val data: PaymentData) {
+        data class Meta(val result: String)
+        data class PaymentData(val orderId: String, val transactions: List<TransactionData>)
+        data class TransactionData(val transactionKey: String, val status: TransactionStatusDto, val reason: String?) {
+            fun toPaymentGatewayInfo(): PaymentGatewayInfo =
+                PaymentGatewayInfo(
+                    transactionKey,
+                    status.toTransactionStatus(),
+                    reason,
+                )
+        }
+
+        enum class TransactionStatusDto {
+            PENDING,
+            SUCCESS,
+            FAILED,
+            ;
+
+            fun toTransactionStatus(): TransactionStatus = when (this) {
+                PENDING -> TransactionStatus.PENDING
+                SUCCESS -> TransactionStatus.SUCCESS
+                FAILED -> TransactionStatus.FAILED
+            }
+        }
+    }
+}

--- a/apps/commerce-api/src/main/kotlin/com/loopers/infrastructure/payment/PgSimulator.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/infrastructure/payment/PgSimulator.kt
@@ -1,0 +1,61 @@
+package com.loopers.infrastructure.payment
+
+import com.loopers.domain.payment.PaymentCommand
+import com.loopers.domain.payment.PaymentGateway
+import com.loopers.domain.payment.model.PaymentGatewayInfo
+import com.loopers.domain.payment.model.TransactionStatus
+import com.loopers.infrastructure.payment.feign.PgClient
+import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker
+import io.github.resilience4j.retry.annotation.Retry
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Component
+
+@Component
+class PgSimulator(private val paymentGatewayClient: PgClient, private val paymentJpaRepository: PaymentJpaRepository) :
+    PaymentGateway {
+
+    private val logger = LoggerFactory.getLogger(PgSimulator::class.java)
+
+    @Value("\${pg-simulator.payment.callback-url}")
+    private lateinit var callbackUrl: String
+
+    @Retry(name = "pgRetry", fallbackMethod = "fallback")
+    @CircuitBreaker(name = "pgCircuit")
+    override fun requestPayment(
+        userId: String,
+        command: PaymentCommand.Pay,
+    ): PaymentGatewayInfo {
+        val request = PgDto.PaymentRequest(
+            orderId = command.orderCode,
+            cardType = command.cardType!!,
+            cardNo = command.cardNo!!,
+            amount = command.amount.toLong(),
+            callbackUrl = callbackUrl,
+        )
+
+        val response = paymentGatewayClient.requestPayment(userId, request)
+        return response.toPaymentGatewayInfo()
+    }
+
+    override fun getPayments(
+        userId: String,
+        orderId: String,
+    ): List<PaymentGatewayInfo> =
+        paymentGatewayClient.getPayments(userId, orderId).data.transactions
+            .map { it.toPaymentGatewayInfo() }
+
+    fun fallback(
+        userId: String,
+        command: PaymentCommand.Pay,
+        ex: Throwable,
+    ): PaymentGatewayInfo {
+        logger.info("PG 시뮬레이터 결제 요청 실패, 주문 코드: ${command.orderCode}, 예외: ${ex.message}")
+
+        return PaymentGatewayInfo(
+            transactionKey = "",
+            status = TransactionStatus.FAILED,
+            reason = "PG 시뮬레이터 결제 요청 실패: ${ex.message}",
+        )
+    }
+}

--- a/apps/commerce-api/src/main/kotlin/com/loopers/infrastructure/payment/feign/PgClient.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/infrastructure/payment/feign/PgClient.kt
@@ -1,0 +1,26 @@
+package com.loopers.infrastructure.payment.feign
+
+import com.loopers.infrastructure.payment.PgDto
+import org.springframework.cloud.openfeign.FeignClient
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestHeader
+
+@FeignClient(
+    name = "pgClient",
+    url = "http://localhost:8082/api/v1/payments",
+)
+interface PgClient {
+
+    @PostMapping
+    fun requestPayment(
+        @RequestHeader("X-USER-ID") userId: String,
+        request: PgDto.PaymentRequest,
+    ): PgDto.PaymentResponse
+
+    @GetMapping
+    fun getPayments(
+        @RequestHeader("X-USER-ID") userId: String,
+        orderId: String,
+    ): PgDto.OrderResponse
+}

--- a/apps/commerce-api/src/main/kotlin/com/loopers/infrastructure/payment/feign/PgClientConfig.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/infrastructure/payment/feign/PgClientConfig.kt
@@ -1,0 +1,24 @@
+package com.loopers.infrastructure.payment.feign
+
+import feign.Logger
+import feign.Request
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import java.util.concurrent.TimeUnit
+
+@Configuration
+class PgClientConfig {
+
+    @Bean
+    fun feignOptions(): Request.Options? = Request.Options(
+        1,
+        TimeUnit.SECONDS,
+        3,
+        TimeUnit.SECONDS,
+        true,
+        )
+
+    // Recommended
+    @Bean
+    fun feignLoggerLevel(): Logger.Level = Logger.Level.BASIC
+}

--- a/apps/commerce-api/src/main/kotlin/com/loopers/infrastructure/support/transaction/TransactionSynchronizationExecutor.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/infrastructure/support/transaction/TransactionSynchronizationExecutor.kt
@@ -1,0 +1,19 @@
+package com.loopers.infrastructure.support.transaction
+
+import org.springframework.stereotype.Component
+import org.springframework.transaction.support.TransactionSynchronization
+import org.springframework.transaction.support.TransactionSynchronizationManager
+
+@Component
+class TransactionSynchronizationExecutor {
+
+    fun afterCommit(action: () -> Unit) {
+        TransactionSynchronizationManager.registerSynchronization(
+            object : TransactionSynchronization {
+                override fun afterCommit() {
+                    action()
+                }
+            },
+        )
+    }
+}

--- a/apps/commerce-api/src/main/kotlin/com/loopers/interfaces/api/order/OrderV1Controller.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/interfaces/api/order/OrderV1Controller.kt
@@ -1,0 +1,24 @@
+package com.loopers.interfaces.api.order
+
+import com.loopers.application.order.OrderFacade
+import com.loopers.interfaces.api.ApiResponse
+import jakarta.validation.Valid
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestHeader
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/v1/orders")
+class OrderV1Controller(private val orderFacade: OrderFacade) {
+
+    @PostMapping
+    fun placeOrder(
+        @Valid @RequestBody request: OrderV1Dto.Request.Order,
+        @RequestHeader("X-USER-ID") userId: String,
+    ): ApiResponse<Unit> {
+        orderFacade.placeOrder(request.toInput(userId))
+        return ApiResponse.success(Unit)
+    }
+}

--- a/apps/commerce-api/src/main/kotlin/com/loopers/interfaces/api/order/OrderV1Dto.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/interfaces/api/order/OrderV1Dto.kt
@@ -1,0 +1,83 @@
+package com.loopers.interfaces.api.order
+
+import com.loopers.application.order.OrderInput
+import com.loopers.domain.payment.model.CardType
+import com.loopers.domain.payment.PaymentMethod
+import com.loopers.domain.payment.PaymentMethod.CARD
+import com.loopers.support.error.CoreException
+import com.loopers.support.error.ErrorType.BAD_REQUEST
+
+object OrderV1Dto {
+
+    class Request {
+
+        data class Order(
+            val orderItems: List<OrderItemDto>,
+            val couponId: Long? = null,
+            val paymentMethod: PaymentMethodDto,
+            val cardType: CardTypeDto? = null,
+            val cardNo: String? = null,
+        ) {
+            data class OrderItemDto(val productId: Long, val quantity: Int)
+
+            init {
+                if (paymentMethod == PaymentMethodDto.CARD) {
+                    require(cardType != null) {
+                        throw CoreException(BAD_REQUEST, "카드 결제 시 카드 타입을 지정해야 합니다.")
+                    }
+                    require(cardNo != null) {
+                        throw CoreException(BAD_REQUEST, "카드 결제 시 카드 번호를 지정해야 합니다.")
+                    }
+                }
+            }
+
+            fun toInput(userId: String): OrderInput.Order = OrderInput.Order(
+                loginId = userId,
+                orderItems = orderItems.map { OrderInput.Order.OrderItem(it.productId, it.quantity) },
+                couponId = couponId,
+                paymentMethod = paymentMethod.toPaymentMethod(),
+                cardType = cardType?.toCardType(),
+                cardNo = cardNo,
+            )
+        }
+    }
+
+    enum class PaymentMethodDto {
+        POINT,
+        CARD,
+        ;
+
+        fun toPaymentMethod(): PaymentMethod = when (this) {
+            POINT -> PaymentMethod.POINT
+            CARD -> PaymentMethod.CARD
+        }
+
+        companion object {
+            fun from(paymentMethod: PaymentMethod) = when (paymentMethod) {
+                PaymentMethod.POINT -> POINT
+                PaymentMethod.CARD -> CARD
+            }
+        }
+    }
+
+    enum class CardTypeDto {
+        SAMSUNG,
+        KB,
+        HYUNDAI,
+        ;
+
+        fun toCardType(): CardType = when (this) {
+            SAMSUNG -> CardType.SAMSUNG
+            KB -> CardType.KB
+            HYUNDAI -> CardType.HYUNDAI
+        }
+
+        companion object {
+            fun from(cardType: CardType) = when (cardType) {
+                CardType.SAMSUNG -> SAMSUNG
+                CardType.KB -> KB
+                CardType.HYUNDAI -> HYUNDAI
+            }
+        }
+    }
+}

--- a/apps/commerce-api/src/main/kotlin/com/loopers/interfaces/api/payment/PaymentV1Controller.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/interfaces/api/payment/PaymentV1Controller.kt
@@ -1,0 +1,23 @@
+package com.loopers.interfaces.api.payment
+
+import com.loopers.application.payment.PaymentFacade
+import com.loopers.interfaces.api.ApiResponse
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import java.time.LocalDateTime
+
+@RestController
+@RequestMapping("/api/v1/payments")
+class PaymentV1Controller(private val paymentFacade: PaymentFacade) {
+
+    @PostMapping("/callback")
+    fun callback(
+        @RequestBody request: PaymentV1Dto.Request.Callback,
+    ): ApiResponse<Unit> {
+        val paidAt = LocalDateTime.now().toString()
+        paymentFacade.complete(request.toInput(paidAt))
+        return ApiResponse.success(Unit)
+    }
+}

--- a/apps/commerce-api/src/main/kotlin/com/loopers/interfaces/api/payment/PaymentV1Dto.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/interfaces/api/payment/PaymentV1Dto.kt
@@ -1,0 +1,67 @@
+package com.loopers.interfaces.api.payment
+
+import com.loopers.application.payment.PaymentInput
+import com.loopers.domain.payment.model.CardType
+import com.loopers.domain.payment.model.TransactionStatus
+
+object PaymentV1Dto {
+
+    class Request {
+
+        data class Callback(
+            val transactionKey: String,
+            val orderId: String,
+            val cardType: CardTypeDto,
+            val cardNo: String,
+            val amount: Long,
+            val status: TransactionStatusDto,
+            val reason: String?,
+        ) {
+            fun toInput(paidAt: String): PaymentInput.Complete =
+                PaymentInput.Complete(
+                    transactionKey = transactionKey,
+                    orderId = orderId,
+                    cardType = cardType.toCardType(),
+                    cardNo = cardNo,
+                    amount = amount,
+                    status = status.toTransactionStatus(),
+                    reason = reason,
+                    paidAt = paidAt,
+                )
+        }
+    }
+
+    enum class CardTypeDto {
+        SAMSUNG,
+        KB,
+        HYUNDAI,
+        ;
+
+        fun toCardType(): CardType = when (this) {
+            SAMSUNG -> CardType.SAMSUNG
+            KB -> CardType.KB
+            HYUNDAI -> CardType.HYUNDAI
+        }
+
+        companion object {
+            fun from(cardType: CardType) = when (cardType) {
+                CardType.SAMSUNG -> SAMSUNG
+                CardType.KB -> KB
+                CardType.HYUNDAI -> HYUNDAI
+            }
+        }
+    }
+
+    enum class TransactionStatusDto {
+        PENDING,
+        SUCCESS,
+        FAILED,
+        ;
+
+        fun toTransactionStatus(): TransactionStatus = when (this) {
+            PENDING -> TransactionStatus.PENDING
+            SUCCESS -> TransactionStatus.SUCCESS
+            FAILED -> TransactionStatus.FAILED
+        }
+    }
+}

--- a/apps/commerce-api/src/main/kotlin/com/loopers/interfaces/scheduler/PaymentHandleScheduler.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/interfaces/scheduler/PaymentHandleScheduler.kt
@@ -1,0 +1,33 @@
+package com.loopers.interfaces.scheduler
+
+import com.loopers.domain.payment.PaymentCommand
+import com.loopers.domain.payment.PaymentService
+import com.loopers.domain.payment.model.TransactionStatus.SUCCESS
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Component
+import java.time.LocalDateTime
+
+@Component
+class PaymentHandleScheduler(private val paymentService: PaymentService) {
+
+    @Scheduled(fixedDelay = 60000)
+    fun handlePayment() {
+        val payments = paymentService.getNotCompletedPayments()
+        payments.forEach { payment ->
+            val findPayment = paymentService.getPaymentByOrderCode(
+                userId = payment.userId.toString(),
+                orderCode = payment.orderCode,
+            ).first()
+
+            if (findPayment.status == SUCCESS) {
+                paymentService.complete(
+                    command = PaymentCommand.Complete(
+                        orderCode = payment.orderCode,
+                        transactionKey = findPayment.transactionKey,
+                        paidAt = LocalDateTime.now().toString(),
+                    ),
+                )
+            }
+        }
+    }
+}

--- a/apps/commerce-api/src/main/kotlin/com/loopers/support/uuid/SimpleUUIDGenerator.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/support/uuid/SimpleUUIDGenerator.kt
@@ -1,0 +1,10 @@
+package com.loopers.support.uuid
+
+import org.springframework.stereotype.Component
+import java.util.UUID
+
+@Component
+class SimpleUUIDGenerator : UUIDGenerator {
+
+    override fun generate(): String = UUID.randomUUID().toString()
+}

--- a/apps/commerce-api/src/main/kotlin/com/loopers/support/uuid/UUIDGenerator.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/support/uuid/UUIDGenerator.kt
@@ -1,0 +1,6 @@
+package com.loopers.support.uuid
+
+interface UUIDGenerator {
+
+    fun generate(): String
+}

--- a/apps/commerce-api/src/main/resources/application.yml
+++ b/apps/commerce-api/src/main/resources/application.yml
@@ -29,6 +29,40 @@ springdoc:
   swagger-ui:
     path: /swagger-ui.html
 
+pg-simulator:
+  payment:
+    callback-url: http://localhost:8080/api/v1/payments/callback
+
+resilience4j:
+  retry:
+    instances:
+      pgRetry:
+        max-attempts: 3 # 최초 요청 1회 + 재시도 2회 = 총 3번
+        wait-duration: 1s
+        retry-exceptions:
+          - feign.FeignException.InternalServerError
+          - feign.RetryableException # 타임아웃 등 네트워크 예외도 모두 커버
+          - java.net.ConnectException
+          - java.net.SocketTimeoutException
+        ignore-exceptions:
+          - feign.FeignException.BadRequest # 400 비즈니스 예외 무시
+        fail-after-max-attempts: true
+
+  circuitbreaker:
+    instances:
+      pgCircuit:
+        sliding-window-type: count_based
+        # 최근 10건을 관찰하지만, 7건 이상이 쌓인 시점부터 임계치 판정을 시작
+        # 1~6건: 상태 판정 안 함, 7~10건: 판정 함, 11건 이후: 계속 최근 10건으로 판정
+        sliding-window-size: 10 # 슬라이딩 윈도우 크기
+        minimum-number-of-calls: 7 # 최소 호출 수
+        failure-rate-threshold: 50 # 실패율이 50% 넘으면 Open
+        slow-call-duration-threshold: 2s # 느린 호출로 간주되는 시간 (2초)
+        slow-call-rate-threshold: 50 # 느린 호출 비율이 50% 넘으면 Open
+        wait-duration-in-open-state: 2s # Open 상태 유지 시간
+        permitted-number-of-calls-in-half-open-state: 1 # Half-Open 상태에서 허용되는 호출 수
+        max-wait-duration-in-half-open-state: 1s # Half-Open 상태에서 최대 대기 시간
+
 ---
 spring:
   config:

--- a/apps/commerce-api/src/test/kotlin/com/loopers/application/order/OrderFacadeIntegrationTest.kt
+++ b/apps/commerce-api/src/test/kotlin/com/loopers/application/order/OrderFacadeIntegrationTest.kt
@@ -1,13 +1,14 @@
 package com.loopers.application.order
 
 import com.loopers.domain.brand.entity.Brand
-import com.loopers.domain.point.vo.Point
+import com.loopers.domain.payment.PaymentMethod.POINT
 import com.loopers.domain.point.entity.PointWallet
+import com.loopers.domain.point.vo.Point
 import com.loopers.domain.product.entity.Product
 import com.loopers.domain.product.model.ProductStatus.SALE
 import com.loopers.domain.stock.entity.Stock
-import com.loopers.domain.user.model.Gender.MALE
 import com.loopers.domain.user.entity.User
+import com.loopers.domain.user.model.Gender.MALE
 import com.loopers.infrastructure.brand.BrandJpaRepository
 import com.loopers.infrastructure.order.OrderJpaRepository
 import com.loopers.infrastructure.point.PointWalletJpaRepository
@@ -72,11 +73,15 @@ class OrderFacadeIntegrationTest(
         val input = OrderInput.Order(
             loginId = "wjsyuwls",
             orderItems = listOf(
-                OrderInput.OrderItem(
+                OrderInput.Order.OrderItem(
                     productId = product.id,
                     quantity = 1,
                 ),
             ),
+            couponId = null,
+            paymentMethod = POINT,
+            cardType = null,
+            cardNo = null,
         )
 
         // When
@@ -84,12 +89,10 @@ class OrderFacadeIntegrationTest(
 
         // Then
         val updatedPointWallet = pointWalletJpaRepository.findByUserId(user.id)!!
-        val updatedStock = stockJpaRepository.findByProductId(product.id)!!
         val orders = orderJpaRepository.findAll()
 
         assertAll(
             { assertThat(updatedPointWallet.balance.value).isEqualTo(BigDecimal("40000.00")) },
-            { assertThat(updatedStock.quantity).isEqualTo(99) },
             { assertThat(orders).hasSize(1) },
             { assertThat(orders[0].userId).isEqualTo(user.id) },
             { assertThat(orders[0].totalPrice).isEqualTo(BigDecimal("10000.00")) },

--- a/apps/commerce-api/src/test/kotlin/com/loopers/application/product/ProductFacadeIntegrationTest.kt
+++ b/apps/commerce-api/src/test/kotlin/com/loopers/application/product/ProductFacadeIntegrationTest.kt
@@ -64,6 +64,7 @@ class ProductFacadeIntegrationTest(
                 publishedAt = "2025-07-31",
                 status = SALE,
                 brandId = 1L,
+                likeCount = 100L,
             )
             productJpaRepository.save(product)
 
@@ -108,6 +109,7 @@ class ProductFacadeIntegrationTest(
                 publishedAt = LocalDate.of(2025, 7, index).toString(),
                 status = SALE,
                 brandId = brand.id,
+                likeCount = index * 10L,
             )
         }
         productJpaRepository.saveAll(products)

--- a/apps/commerce-api/src/test/kotlin/com/loopers/domain/order/OrderServiceTest.kt
+++ b/apps/commerce-api/src/test/kotlin/com/loopers/domain/order/OrderServiceTest.kt
@@ -1,21 +1,18 @@
 package com.loopers.domain.order
 
-import com.loopers.domain.order.model.OrderStatus.PAYMENT_COMPLETED
-import com.loopers.domain.order.model.OrderStatus.PAYMENT_PENDING
-import com.loopers.domain.order.entity.Order
 import com.loopers.domain.order.entity.OrderLine
+import com.loopers.domain.order.model.OrderStatus.PENDING
 import com.loopers.support.IntegrationTestSupport
-import com.loopers.support.error.CoreException
-import com.loopers.support.error.ErrorType.NOT_FOUND
+import com.loopers.support.uuid.UUIDGenerator
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertAll
-import org.junit.jupiter.api.assertThrows
 import java.math.BigDecimal
 
 class OrderServiceTest(
     private val orderService: OrderService,
     private val orderRepository: OrderRepository,
+    private val uuidGenerator: UUIDGenerator,
 ) : IntegrationTestSupport() {
 
     @Test
@@ -32,7 +29,6 @@ class OrderServiceTest(
         val command = OrderCommand.PlaceOrder(
             userId = 1L,
             orderLines = orderLines,
-            paymentAmount = BigDecimal(20_000L),
         )
 
         // When
@@ -44,50 +40,7 @@ class OrderServiceTest(
             { assertThat(actual.orderLines).hasSize(1) },
             { assertThat(actual.orderLines[0].productId).isEqualTo(1L) },
             { assertThat(actual.orderLines[0].quantity).isEqualTo(2) },
-            { assertThat(actual.status).isEqualTo(PAYMENT_PENDING) },
+            { assertThat(actual.status).isEqualTo(PENDING) },
         )
-    }
-
-    @Test
-    fun `존재하지 않는 주문의 결제 완료시 예외가 발생한다`() {
-        // Given
-        val nonExistentOrderId = 999L
-
-        // When
-        val actual = assertThrows<CoreException> {
-            orderService.completePayment(nonExistentOrderId)
-        }
-
-        // Then
-        assertAll(
-            { assertThat(actual.errorType).isEqualTo(NOT_FOUND) },
-            { assertThat(actual.message).isEqualTo("주문을 찾을 수 없습니다. 주문 ID: $nonExistentOrderId") },
-        )
-    }
-
-    @Test
-    fun `정상적인 결제 완료 요청시 주문 상태가 변경된다`() {
-        // Given
-        val order = Order(
-            userId = 1L,
-            orderLines = listOf(
-                OrderLine(
-                    productId = 1L,
-                    quantity = 1,
-                    unitPrice = BigDecimal(10_000L),
-                ),
-            ),
-            status = PAYMENT_PENDING,
-            paymentAmount = BigDecimal(10_000L),
-        )
-        orderRepository.save(order)
-
-        // When
-        orderService.completePayment(order.id)
-
-        // Then
-        val actual = orderRepository.findById(order.id)!!
-
-        assertThat(actual.status).isEqualTo(PAYMENT_COMPLETED)
     }
 }

--- a/apps/commerce-api/src/test/kotlin/com/loopers/domain/payment/CardPaymentProcessorTest.kt
+++ b/apps/commerce-api/src/test/kotlin/com/loopers/domain/payment/CardPaymentProcessorTest.kt
@@ -1,0 +1,84 @@
+package com.loopers.domain.payment
+
+import com.loopers.domain.payment.PaymentMethod.CARD
+import com.loopers.domain.payment.model.CardType.HYUNDAI
+import com.loopers.infrastructure.payment.PaymentJpaRepository
+import com.loopers.infrastructure.support.transaction.TransactionSynchronizationExecutor
+import com.loopers.support.IntegrationTestSupport
+import com.ninjasquad.springmockk.MockkBean
+import com.ninjasquad.springmockk.SpykBean
+import io.mockk.every
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.tuple
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+import java.util.UUID
+
+class CardPaymentProcessorTest(
+    @SpykBean
+    private val cardPaymentProcessor: CardPaymentProcessor,
+    private val paymentJpaRepository: PaymentJpaRepository,
+    @MockkBean
+    private val transactionSynchronizationExecutor: TransactionSynchronizationExecutor,
+) : IntegrationTestSupport() {
+
+    @Nested
+    open inner class `카드 방식으로 결제를 요청할 때, ` {
+
+        @Test
+        fun `결제 내역을 정상적으로 저장한다`() {
+            // given
+            every { transactionSynchronizationExecutor.afterCommit(any()) } answers {
+                // do nothing
+            }
+
+            val orderCode = UUID.randomUUID().toString()
+            val command = PaymentCommand.Pay(
+                userId = 1L,
+                orderCode = orderCode,
+                amount = BigDecimal(10_000L),
+                paymentMethod = CARD,
+                cardType = HYUNDAI,
+                cardNo = "1234-1234-1234-1234",
+            )
+
+            // when
+            cardPaymentProcessor.process(command)
+
+            // then
+            val actual = paymentJpaRepository.findAll()
+
+            assertThat(actual).hasSize(1)
+                .extracting("userId", "orderCode", "amount", "paymentMethod", "cardType", "cardNo")
+                .containsExactlyInAnyOrder(
+                    tuple(1L, orderCode, BigDecimal("10000.00"), CARD, HYUNDAI, "1234-1234-1234-1234"),
+                )
+        }
+
+        @Test
+        fun `결제 내역을 정상적으로 저장하면, PG에 결제를 정상 요청한다`() {
+            // given
+            every { transactionSynchronizationExecutor.afterCommit(any()) } answers {
+                // do nothing
+            }
+
+            val orderCode = UUID.randomUUID().toString()
+            val command = PaymentCommand.Pay(
+                userId = 1L,
+                orderCode = orderCode,
+                amount = BigDecimal(10_000L),
+                paymentMethod = CARD,
+                cardType = HYUNDAI,
+                cardNo = "1234-1234-1234-1234",
+            )
+
+            // when
+            cardPaymentProcessor.process(command)
+
+            // then
+            verify(exactly = 1) { transactionSynchronizationExecutor.afterCommit(any()) }
+        }
+    }
+}

--- a/apps/commerce-api/src/test/kotlin/com/loopers/domain/payment/PaymentServiceTest.kt
+++ b/apps/commerce-api/src/test/kotlin/com/loopers/domain/payment/PaymentServiceTest.kt
@@ -1,0 +1,144 @@
+package com.loopers.domain.payment
+
+import com.loopers.domain.payment.PaymentMethod.CARD
+import com.loopers.domain.payment.PaymentMethod.POINT
+import com.loopers.domain.payment.entity.Payment
+import com.loopers.domain.payment.model.CardType.HYUNDAI
+import com.loopers.domain.payment.model.PaymentStatus.PENDING
+import com.loopers.domain.payment.model.PaymentStatus.SUCCESS
+import com.loopers.infrastructure.payment.PaymentJpaRepository
+import com.loopers.support.IntegrationTestSupport
+import com.loopers.support.error.CoreException
+import com.loopers.support.error.ErrorType.NOT_FOUND
+import com.ninjasquad.springmockk.MockkBean
+import com.ninjasquad.springmockk.SpykBean
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertAll
+import org.junit.jupiter.api.assertThrows
+import java.math.BigDecimal
+import java.util.UUID
+
+class PaymentServiceTest(
+    @SpykBean
+    private val paymentService: PaymentService,
+    @MockkBean
+    private val cardPaymentProcessor: CardPaymentProcessor,
+    @MockkBean
+    private val pointPaymentProcessor: PointPaymentProcessor,
+    private val paymentJpaRepository: PaymentJpaRepository,
+) : IntegrationTestSupport() {
+
+    @BeforeEach
+    fun setUp() {
+        every { cardPaymentProcessor.paymentMethod() } returns CARD
+        every { cardPaymentProcessor.process(any()) } just Runs
+        every { pointPaymentProcessor.paymentMethod() } returns POINT
+        every { pointPaymentProcessor.process(any()) } just Runs
+    }
+
+    @Nested
+    inner class `결제를 할 때, ` {
+
+        @Test
+        fun `카드 방식으로 결제를 요청하면, 카드 결제 방식으로 프로세스가 진행된다`() {
+            // given
+            val command = PaymentCommand.Pay(
+                userId = 1L,
+                orderCode = UUID.randomUUID().toString(),
+                amount = BigDecimal(10_000L),
+                paymentMethod = CARD,
+                cardType = HYUNDAI,
+                cardNo = "1234-1234-1234-1234",
+            )
+
+            // when
+            paymentService.pay(command)
+
+            // then
+            verify(exactly = 1) { cardPaymentProcessor.process(command) }
+        }
+
+        @Test
+        fun `포인트 방식으로 결제를 요청하면, 포인트 결제 방식으로 프로세스가 진행된다`() {
+            // given
+            val command = PaymentCommand.Pay(
+                userId = 1L,
+                orderCode = UUID.randomUUID().toString(),
+                amount = BigDecimal(10_000L),
+                paymentMethod = POINT,
+            )
+
+            // when
+            paymentService.pay(command)
+
+            // then
+            verify(exactly = 1) { pointPaymentProcessor.process(command) }
+        }
+    }
+
+    @Nested
+    inner class `결제를 완료할 때, ` {
+
+        @Test
+        fun `주문 코드에 해당하는 결제 정보를 찾지 못하면, NOT_FOUND 예외가 발생한다`() {
+            // given
+            val orderCode = UUID.randomUUID().toString()
+            val command = PaymentCommand.Complete(
+                orderCode = orderCode,
+                transactionKey = "transaction-key",
+                paidAt = "2023-10-01T12:00:00",
+            )
+
+            // when
+            val actual = assertThrows<CoreException> {
+                paymentService.complete(command)
+            }
+
+            // then
+            assertAll(
+                { assertThat(actual.errorType).isEqualTo(NOT_FOUND) },
+                { assertThat(actual.message).isEqualTo("결제 정보를 찾을 수 없습니다. 주문 코드: $orderCode") },
+            )
+        }
+
+        @Test
+        fun `정상적으로 완료 처리하고, 저장한다`() {
+            // given
+            val orderCode = UUID.randomUUID().toString()
+
+            val payment = Payment(
+                orderCode = orderCode,
+                userId = 1L,
+                amount = BigDecimal(10_000L),
+                paymentMethod = CARD,
+                cardType = HYUNDAI,
+                cardNo = "1234-1234-1234-1234",
+                status = PENDING,
+            )
+            paymentJpaRepository.save(payment)
+
+            val command = PaymentCommand.Complete(
+                orderCode = orderCode,
+                transactionKey = "transaction-key",
+                paidAt = "2023-10-01T12:00:00",
+            )
+
+            // when
+            paymentService.complete(command)
+
+            // then
+            val actual = paymentJpaRepository.findByOrderCode(orderCode)!!
+
+            assertThat(actual.status).isEqualTo(SUCCESS)
+            assertThat(actual.transactionKey).isEqualTo("transaction-key")
+            assertThat(actual.paidAt).isEqualTo("2023-10-01T12:00:00")
+        }
+    }
+}

--- a/apps/commerce-api/src/test/kotlin/com/loopers/domain/payment/PointPaymentProcessorTest.kt
+++ b/apps/commerce-api/src/test/kotlin/com/loopers/domain/payment/PointPaymentProcessorTest.kt
@@ -1,0 +1,76 @@
+package com.loopers.domain.payment
+
+import com.loopers.domain.payment.PaymentMethod.POINT
+import com.loopers.domain.point.PointWalletRepository
+import com.loopers.domain.point.entity.PointWallet
+import com.loopers.domain.point.vo.Point
+import com.loopers.support.IntegrationTestSupport
+import com.loopers.support.error.CoreException
+import com.loopers.support.error.ErrorType.NOT_FOUND
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertAll
+import org.junit.jupiter.api.assertThrows
+import java.math.BigDecimal
+import java.util.UUID
+
+class PointPaymentProcessorTest(
+    private val pointPaymentProcessor: PointPaymentProcessor,
+    private val pointWalletRepository: PointWalletRepository,
+) : IntegrationTestSupport() {
+
+    @Nested
+    inner class `포인트로 결제를 진행할 때, ` {
+
+        @Test
+        fun `포인트 지갑이 존재하지 않는 사용자 ID로 요청하면, NOT_FOUND 예외가 발생한다`() {
+            // given
+            val nonExistentUserId = 1L
+            val command = PaymentCommand.Pay(
+                userId = nonExistentUserId,
+                orderCode = UUID.randomUUID().toString(),
+                amount = BigDecimal(10_000L),
+                paymentMethod = POINT,
+            )
+
+            // when
+            val actual = assertThrows<CoreException> {
+                pointPaymentProcessor.process(command)
+            }
+
+            // then
+            assertAll(
+                { assertThat(actual.errorType).isEqualTo(NOT_FOUND) },
+                { assertThat(actual.message).isEqualTo("해당 사용자의 포인트 지갑을 찾을 수 없습니다.") },
+            )
+        }
+
+        @Test
+        fun `잔액이 10,000 포인트인 사용자가 10,000 포인트 결제를 요청하면, 잔액은 0 포인트가 된다`() {
+            // given
+            val existentUserId = 1L
+            pointWalletRepository.save(
+                PointWallet(
+                    userId = existentUserId,
+                    balance = Point.of(10_000L),
+                ),
+            )
+
+            val command = PaymentCommand.Pay(
+                userId = existentUserId,
+                orderCode = UUID.randomUUID().toString(),
+                amount = BigDecimal(10_000L),
+                paymentMethod = POINT,
+            )
+
+            // when
+            pointPaymentProcessor.process(command)
+
+            // then
+            val actual = pointWalletRepository.findByUserId(existentUserId)!!
+
+            assertThat(actual.balance.value).isEqualTo(BigDecimal("0.00"))
+        }
+    }
+}

--- a/apps/commerce-api/src/test/kotlin/com/loopers/domain/payment/entity/PaymentTest.kt
+++ b/apps/commerce-api/src/test/kotlin/com/loopers/domain/payment/entity/PaymentTest.kt
@@ -1,0 +1,233 @@
+package com.loopers.domain.payment.entity
+
+import com.loopers.domain.payment.PaymentMethod.CARD
+import com.loopers.domain.payment.model.CardType.HYUNDAI
+import com.loopers.domain.payment.model.PaymentStatus.PENDING
+import com.loopers.domain.payment.model.PaymentStatus.SUCCESS
+import com.loopers.support.error.CoreException
+import com.loopers.support.error.ErrorType.BAD_REQUEST
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertAll
+import org.junit.jupiter.api.assertThrows
+import java.math.BigDecimal
+
+class PaymentTest {
+
+    @Nested
+    inner class `결제 정보를 생성할 때, ` {
+
+        @Test
+        fun `결재 금액이 0 이하의 정수이면, BAD_REQUEST 예외가 발생한다`() {
+            // given
+            val invalidAmount = BigDecimal.ZERO
+            val userId = 1L
+            val orderCode = "orderCode"
+            val paymentMethod = CARD
+            val cardType = HYUNDAI
+            val cardNo = "1234-5678-9012-3456"
+            val status = PENDING
+
+            // when
+            val actual = assertThrows<CoreException> {
+                Payment(
+                    amount = invalidAmount,
+                    userId = userId,
+                    orderCode = orderCode,
+                    paymentMethod = paymentMethod,
+                    cardType = cardType,
+                    cardNo = cardNo,
+                    status = status,
+                )
+            }
+
+            // then
+            assertAll(
+                { assertThat(actual.errorType).isEqualTo(BAD_REQUEST) },
+                { assertThat(actual.message).isEqualTo("결제 금액은 0보다 커야 합니다.") },
+            )
+        }
+
+        @Test
+        fun `카드 결제 시 카드 타입을 지정하지 않으면, BAD_REQUEST 예외가 발생한다`() {
+            // given
+            val amount = BigDecimal.ONE
+            val userId = 1L
+            val orderCode = "orderCode"
+            val paymentMethod = CARD
+            val cardNo = "1234-5678-9012-3456"
+            val status = PENDING
+
+            // when
+            val actual = assertThrows<CoreException> {
+                Payment(
+                    amount = amount,
+                    userId = userId,
+                    orderCode = orderCode,
+                    paymentMethod = paymentMethod,
+                    cardType = null,
+                    cardNo = cardNo,
+                    status = status,
+                )
+            }
+
+            // then
+            assertAll(
+                { assertThat(actual.errorType).isEqualTo(BAD_REQUEST) },
+                { assertThat(actual.message).isEqualTo("카드 결제 시 카드 타입을 지정해야 합니다.") },
+            )
+        }
+
+        @Test
+        fun `카드 결제 시 카드 번호를 지정하지 않으면, BAD_REQUEST 예외가 발생한다`() {
+            // given
+            val amount = BigDecimal.ONE
+            val userId = 1L
+            val orderCode = "orderCode"
+            val paymentMethod = CARD
+            val cardType = HYUNDAI
+            val status = PENDING
+
+            // when
+            val actual = assertThrows<CoreException> {
+                Payment(
+                    amount = amount,
+                    userId = userId,
+                    orderCode = orderCode,
+                    paymentMethod = paymentMethod,
+                    cardType = cardType,
+                    cardNo = null,
+                    status = status,
+                )
+            }
+
+            // then
+            assertAll(
+                { assertThat(actual.errorType).isEqualTo(BAD_REQUEST) },
+                { assertThat(actual.message).isEqualTo("카드 결제 시 카드 번호를 지정해야 합니다.") },
+            )
+        }
+
+        @Test
+        fun `정상 생성할 수 있다`() {
+            // given
+            val amount = BigDecimal.ONE
+            val userId = 1L
+            val orderCode = "orderCode"
+            val paymentMethod = CARD
+            val cardType = HYUNDAI
+            val cardNo = "1234-5678-9012-3456"
+            val status = PENDING
+
+            // when
+            val payment = Payment(
+                amount = amount,
+                userId = userId,
+                orderCode = orderCode,
+                paymentMethod = paymentMethod,
+                cardType = cardType,
+                cardNo = cardNo,
+                status = status,
+            )
+
+            // then
+            assertAll(
+                { assertThat(payment.amount).isEqualTo(BigDecimal.ONE) },
+                { assertThat(payment.userId).isEqualTo(1L) },
+                { assertThat(payment.orderCode).isEqualTo("orderCode") },
+                { assertThat(payment.paymentMethod).isEqualTo(CARD) },
+                { assertThat(payment.cardType).isEqualTo(HYUNDAI) },
+                { assertThat(payment.cardNo).isEqualTo("1234-5678-9012-3456") },
+                { assertThat(payment.status).isEqualTo(PENDING) },
+            )
+        }
+    }
+
+    @Nested
+    inner class `결제를 완료 처리할 때, ` {
+
+        @Test
+        fun `거래 키가 비어있으면, BAD_REQUEST 예외가 발생한다`() {
+            // given
+            val payment = Payment(
+                amount = BigDecimal.ONE,
+                userId = 1L,
+                orderCode = "orderCode",
+                paymentMethod = CARD,
+                cardType = HYUNDAI,
+                cardNo = "1234-5678-9012-3456",
+                status = PENDING,
+            )
+
+            val transactionKey = " "
+            val paidAt = "2023-10-01T12:00:00"
+
+            // when
+            val actual = assertThrows<CoreException> {
+                payment.complete(transactionKey, paidAt)
+            }
+
+            // then
+            assertAll(
+                { assertThat(actual.errorType).isEqualTo(BAD_REQUEST) },
+                { assertThat(actual.message).isEqualTo("거래 키는 비어있을 수 없습니다.") },
+            )
+        }
+
+        @Test
+        fun `결제 완료 시간이 비어있으면, BAD_REQUEST 예외가 발생한다`() {
+            // given
+            val payment = Payment(
+                amount = BigDecimal.ONE,
+                userId = 1L,
+                orderCode = "orderCode",
+                paymentMethod = CARD,
+                cardType = HYUNDAI,
+                cardNo = "1234-5678-9012-3456",
+                status = PENDING,
+            )
+
+            val transactionKey = "transactionKey"
+            val paidAt = " "
+
+            // when
+            val actual = assertThrows<CoreException> {
+                payment.complete(transactionKey, paidAt)
+            }
+
+            // then
+            assertAll(
+                { assertThat(actual.errorType).isEqualTo(BAD_REQUEST) },
+                { assertThat(actual.message).isEqualTo("결제 완료 시간은 비어있을 수 없습니다.") },
+            )
+        }
+
+        @Test
+        fun `성공적으로 완료 처리를 할 수 있다`() {
+            // given
+            val payment = Payment(
+                amount = BigDecimal.ONE,
+                userId = 1L,
+                orderCode = "orderCode",
+                paymentMethod = CARD,
+                cardType = HYUNDAI,
+                cardNo = "1234-5678-9012-3456",
+                status = PENDING,
+            )
+
+            val transactionKey = "transactionKey"
+            val paidAt = "2023-10-01T12:00:00"
+
+            // when
+            payment.complete(transactionKey, paidAt)
+
+            // then
+            assertAll(
+                { assertThat(payment.status).isEqualTo(SUCCESS) },
+                { assertThat(payment.transactionKey).isEqualTo("transactionKey") },
+                { assertThat(payment.paidAt).isEqualTo("2023-10-01T12:00:00") },
+            )
+        }
+    }
+}

--- a/apps/commerce-api/src/test/kotlin/com/loopers/domain/product/ProductServiceTest.kt
+++ b/apps/commerce-api/src/test/kotlin/com/loopers/domain/product/ProductServiceTest.kt
@@ -45,7 +45,13 @@ class ProductServiceTest(
         @Test
         fun `존재하는 상품 ID로 조회하면, 해당 상품 정보를 반환한다`() {
             // Given
-            val product = Product("테스트 상품", 10000.toBigDecimal(), 1L, "2025-07-30", SALE)
+            val product = Product(
+                brandId = 1L,
+                name = "테스트 상품",
+                price = 10000.toBigDecimal(),
+                publishedAt = "2025-07-30",
+                status = SALE,
+            )
             productJpaRepository.save(product)
 
             // When
@@ -72,11 +78,11 @@ class ProductServiceTest(
             // Given
             val products = (1..20).map { i ->
                 Product(
-                    "상품$i",
-                    (10000 * i).toBigDecimal(),
-                    1L,
-                    LocalDate.of(2025, 7, i).toString(),
-                    SALE,
+                    brandId = 1L,
+                    name = "상품$i",
+                    price = (10000 * i).toBigDecimal(),
+                    publishedAt = LocalDate.of(2025, 7, i).toString(),
+                    status = SALE,
                 )
             }
             productJpaRepository.saveAll(products)
@@ -112,11 +118,11 @@ class ProductServiceTest(
             // Given
             val products = (1..20).map { i ->
                 Product(
-                    "상품$i",
-                    (10000 * i).toBigDecimal(),
-                    1L,
-                    LocalDate.of(2025, 7, i).toString(),
-                    SALE,
+                    brandId = 1L,
+                    name = "상품$i",
+                    price = (10000 * i).toBigDecimal(),
+                    publishedAt = LocalDate.of(2025, 7, i).toString(),
+                    status = SALE,
                 )
             }
             productJpaRepository.saveAll(products)

--- a/apps/commerce-api/src/test/kotlin/com/loopers/infrastructure/payment/PgSimulatorCircuitBreakerTest.kt
+++ b/apps/commerce-api/src/test/kotlin/com/loopers/infrastructure/payment/PgSimulatorCircuitBreakerTest.kt
@@ -1,0 +1,236 @@
+package com.loopers.infrastructure.payment
+
+import com.loopers.domain.payment.PaymentCommand
+import com.loopers.domain.payment.PaymentMethod.CARD
+import com.loopers.domain.payment.model.CardType
+import com.loopers.infrastructure.payment.feign.PgClient
+import com.loopers.support.IntegrationTestSupport
+import com.ninjasquad.springmockk.MockkBean
+import io.github.resilience4j.circuitbreaker.CircuitBreaker
+import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+import java.util.UUID
+import java.util.concurrent.atomic.AtomicReference
+
+class PgSimulatorCircuitBreakerTest(
+    private val pgSimulator: PgSimulator,
+    private val circuitBreakerRegistry: CircuitBreakerRegistry,
+    @MockkBean
+    private val pgClient: PgClient,
+) : IntegrationTestSupport() {
+
+    @BeforeEach
+    fun setUp() {
+        circuitBreakerRegistry.circuitBreaker("pgCircuit").reset()
+    }
+
+    @Test
+    fun `7회 중 3회 성공 4회 실패 시 서킷브레이커가 OPEN 상태가 된다`() {
+        // given
+        every { pgClient.requestPayment(any(), any()) }
+            .returnsMany(
+                listOf(
+                    mockk(relaxed = true),
+                    mockk(relaxed = true),
+                    mockk(relaxed = true),
+                ),
+            )
+            .andThenAnswer { throw RuntimeException("PG 장애 #1") }
+            .andThenAnswer { throw RuntimeException("PG 장애 #2") }
+            .andThenAnswer { throw RuntimeException("PG 장애 #3") }
+            .andThenAnswer { throw RuntimeException("PG 장애 #4") }
+
+        val command = createCommand()
+
+        // when
+        repeat(7) {
+            try {
+                pgSimulator.requestPayment("user", command)
+            } catch (_: Exception) {}
+        }
+
+        // then
+        val circuitBreaker = circuitBreakerRegistry.circuitBreaker("pgCircuit")
+        assertEquals("OPEN", circuitBreaker.state.name)
+    }
+
+    @Test
+    fun `6회 중 3회 성공 3회 실패 시 서킷브레이커는 OPEN 상태가 아니다`() {
+        // given
+        every { pgClient.requestPayment(any(), any()) }
+            .returnsMany(
+                listOf(
+                    mockk(relaxed = true),
+                    mockk(relaxed = true),
+                    mockk(relaxed = true),
+                ),
+            )
+            .andThenAnswer { throw RuntimeException("PG 장애 #1") }
+            .andThenAnswer { throw RuntimeException("PG 장애 #2") }
+            .andThenAnswer { throw RuntimeException("PG 장애 #3") }
+
+        val command = createCommand()
+
+        // when
+        repeat(6) {
+            try {
+                pgSimulator.requestPayment("user", command)
+            } catch (_: Exception) {}
+        }
+
+        // then
+        val circuitBreaker = circuitBreakerRegistry.circuitBreaker("pgCircuit")
+        assertEquals("CLOSED", circuitBreaker.state.name)
+    }
+
+    @Test
+    fun `7회 중 3회 성공 4회 실패 후 대기 시간 경과 시 서킷브레이커가 HALF_OPEN 상태로 전환된다`() {
+        // given
+        every { pgClient.requestPayment(any(), any()) }
+            .returnsMany(
+                listOf(
+                    mockk(relaxed = true),
+                    mockk(relaxed = true),
+                    mockk(relaxed = true),
+                ),
+            )
+            .andThenAnswer { throw RuntimeException("PG 장애 #1") }
+            .andThenAnswer { throw RuntimeException("PG 장애 #2") }
+            .andThenAnswer { throw RuntimeException("PG 장애 #3") }
+            .andThenAnswer { throw RuntimeException("PG 장애 #4") }
+
+        val command = createCommand()
+
+        // when
+        repeat(7) {
+            try {
+                pgSimulator.requestPayment("user", command)
+            } catch (_: Exception) {}
+        }
+
+        Thread.sleep(2001)
+
+        // then
+        val circuitBreaker = circuitBreakerRegistry.circuitBreaker("pgCircuit")
+
+        val seenState = AtomicReference<CircuitBreaker.State>()
+        circuitBreaker.decorateSupplier {
+            seenState.set(circuitBreaker.state)
+        }.get()
+
+        assertEquals("HALF_OPEN", seenState.get().name)
+    }
+
+    @Test
+    fun `서킷브레이커가 OPEN 상태에서 HALF_OPEN을 거쳐 정상 호출 시 CLOSED로 복구된다`() {
+        // given
+        every { pgClient.requestPayment(any(), any()) }
+            .returnsMany(
+                listOf(
+                    mockk(relaxed = true),
+                    mockk(relaxed = true),
+                    mockk(relaxed = true),
+                ),
+            )
+            .andThenAnswer { throw RuntimeException("PG 장애 #1") }
+            .andThenAnswer { throw RuntimeException("PG 장애 #2") }
+            .andThenAnswer { throw RuntimeException("PG 장애 #3") }
+            .andThenAnswer { throw RuntimeException("PG 장애 #4") }
+
+        val command = createCommand()
+
+        repeat(7) {
+            try {
+                pgSimulator.requestPayment("user", command)
+            } catch (_: Exception) {}
+        }
+
+        val circuitBreaker = circuitBreakerRegistry.circuitBreaker("pgCircuit")
+        assertEquals("OPEN", circuitBreaker.state.name)
+
+        // when
+        Thread.sleep(2001)
+        every { pgClient.requestPayment(any(), any()) } returns mockk(relaxed = true)
+        repeat(2) {
+            try {
+                pgSimulator.requestPayment("user", command)
+            } catch (_: Exception) {}
+        }
+
+        // then
+        assertEquals("CLOSED", circuitBreaker.state.name)
+    }
+
+    @Test
+    fun `정상 호출이 반복되어도 서킷브레이커는 항상 CLOSED 상태이다`() {
+        // given
+        every { pgClient.requestPayment(any(), any()) } returns mockk(relaxed = true)
+        val command = createCommand()
+
+        // when
+        repeat(20) {
+            pgSimulator.requestPayment("user", command)
+
+            // then
+            val circuitBreaker = circuitBreakerRegistry.circuitBreaker("pgCircuit")
+            assertEquals("CLOSED", circuitBreaker.state.name)
+        }
+    }
+
+    @Test
+    fun `7회 중 3회 성공 4회 슬로우콜 시 서킷브레이커가 OPEN 상태가 된다`() {
+        // given
+        every { pgClient.requestPayment(any(), any()) }
+            .returnsMany(
+                listOf(
+                    mockk(relaxed = true),
+                    mockk(relaxed = true),
+                    mockk(relaxed = true),
+                ),
+            )
+            .andThenAnswer {
+                Thread.sleep(3000)
+                mockk(relaxed = true)
+            }
+            .andThenAnswer {
+                Thread.sleep(3000)
+                mockk(relaxed = true)
+            }
+            .andThenAnswer {
+                Thread.sleep(3000)
+                mockk(relaxed = true)
+            }
+            .andThenAnswer {
+                Thread.sleep(3000)
+                mockk(relaxed = true)
+            }
+
+        val command = createCommand()
+
+        // when
+        repeat(7) {
+            try {
+                pgSimulator.requestPayment("user", command)
+            } catch (_: Exception) {}
+        }
+
+        // then
+        val circuitBreaker = circuitBreakerRegistry.circuitBreaker("pgCircuit")
+        assertEquals("OPEN", circuitBreaker.state.name)
+    }
+
+    private fun createCommand() =
+        PaymentCommand.Pay(
+        userId = 1L,
+        orderCode = UUID.randomUUID().toString(),
+        amount = BigDecimal.ONE,
+        paymentMethod = CARD,
+        cardType = CardType.SAMSUNG,
+        cardNo = "1234-5678-9012-3456",
+    )
+}

--- a/apps/commerce-api/src/test/kotlin/com/loopers/support/E2ETestSupport.kt
+++ b/apps/commerce-api/src/test/kotlin/com/loopers/support/E2ETestSupport.kt
@@ -2,6 +2,7 @@ package com.loopers.support
 
 import com.loopers.CommerceApiApplication
 import com.loopers.utils.DatabaseCleanUp
+import com.loopers.utils.RedisCleanUp
 import org.junit.jupiter.api.AfterEach
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
@@ -17,8 +18,12 @@ abstract class E2ETestSupport {
     @Autowired
     protected lateinit var databaseCleanUp: DatabaseCleanUp
 
+    @Autowired
+    protected lateinit var redisCleanUp: RedisCleanUp
+
     @AfterEach
     fun tearDown() {
         databaseCleanUp.truncateAllTables()
+        redisCleanUp.truncateAll()
     }
 }

--- a/apps/commerce-api/src/test/kotlin/com/loopers/support/IntegrationTestSupport.kt
+++ b/apps/commerce-api/src/test/kotlin/com/loopers/support/IntegrationTestSupport.kt
@@ -1,6 +1,7 @@
 package com.loopers.support
 
 import com.loopers.utils.DatabaseCleanUp
+import com.loopers.utils.RedisCleanUp
 import org.junit.jupiter.api.AfterEach
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
@@ -13,8 +14,12 @@ abstract class IntegrationTestSupport {
     @Autowired
     protected lateinit var databaseCleanUp: DatabaseCleanUp
 
+    @Autowired
+    protected lateinit var redisCleanUp: RedisCleanUp
+
     @AfterEach
     fun tearDown() {
         databaseCleanUp.truncateAllTables()
+        redisCleanUp.truncateAll()
     }
 }

--- a/apps/pg-simulator/README.md
+++ b/apps/pg-simulator/README.md
@@ -1,0 +1,42 @@
+## PG-Simulator (PaymentGateway)
+
+### Description
+Loopback BE 과정을 위해 PaymentGateway 를 시뮬레이션하는 App Module 입니다.
+`local` 프로필로 실행 권장하며, 커머스 서비스와의 동시 실행을 위해 서버 포트가 조정되어 있습니다.
+- server port : 8082
+- actuator port : 8083
+
+### Getting Started
+부트 서버를 아래 명령어 혹은 `intelliJ` 통해 실행해주세요.
+```shell
+./gradlew :apps:pg-simulator:bootRun
+```
+
+API 는 아래와 같이 주어지니, 커머스 서비스와 동시에 실행시킨 후 진행해주시면 됩니다.
+- 결제 요청 API
+- 결제 정보 확인 `by transactionKey`
+- 결제 정보 목록 조회 `by orderId`
+
+```http request
+### 결제 요청
+POST {{pg-simulator}}/api/v1/payments
+X-USER-ID: 135135
+Content-Type: application/json
+
+{
+  "orderId": "1351039135",
+  "cardType": "SAMSUNG",
+  "cardNo": "1234-5678-9814-1451",
+  "amount" : "5000",
+  "callbackUrl": "http://localhost:8080/api/v1/examples/callback"
+}
+
+### 결제 정보 확인
+GET {{pg-simulator}}/api/v1/payments/20250816:TR:9577c5
+X-USER-ID: 135135
+
+### 주문에 엮인 결제 정보 조회
+GET {{pg-simulator}}/api/v1/payments?orderId=1351039135
+X-USER-ID: 135135
+
+```

--- a/apps/pg-simulator/build.gradle.kts
+++ b/apps/pg-simulator/build.gradle.kts
@@ -1,0 +1,24 @@
+plugins {
+    id("org.jetbrains.kotlin.plugin.jpa")
+}
+
+dependencies {
+    // add-ons
+    implementation(project(":modules:jpa"))
+    implementation(project(":modules:redis"))
+    implementation(project(":supports:jackson"))
+    implementation(project(":supports:logging"))
+    implementation(project(":supports:monitoring"))
+
+    // web
+    implementation("org.springframework.boot:spring-boot-starter-web")
+    implementation("org.springframework.boot:spring-boot-starter-actuator")
+    implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:${project.properties["springDocOpenApiVersion"]}")
+
+    // querydsl
+    kapt("com.querydsl:querydsl-apt::jakarta")
+
+    // test-fixtures
+    testImplementation(testFixtures(project(":modules:jpa")))
+    testImplementation(testFixtures(project(":modules:redis")))
+}

--- a/apps/pg-simulator/src/main/kotlin/com/loopers/PaymentGatewayApplication.kt
+++ b/apps/pg-simulator/src/main/kotlin/com/loopers/PaymentGatewayApplication.kt
@@ -1,0 +1,24 @@
+package com.loopers
+
+import jakarta.annotation.PostConstruct
+import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan
+import org.springframework.boot.runApplication
+import org.springframework.scheduling.annotation.EnableAsync
+import java.util.TimeZone
+
+@ConfigurationPropertiesScan
+@EnableAsync
+@SpringBootApplication
+class PaymentGatewayApplication {
+
+    @PostConstruct
+    fun started() {
+        // set timezone
+        TimeZone.setDefault(TimeZone.getTimeZone("Asia/Seoul"))
+    }
+}
+
+fun main(args: Array<String>) {
+    runApplication<PaymentGatewayApplication>(*args)
+}

--- a/apps/pg-simulator/src/main/kotlin/com/loopers/application/payment/OrderInfo.kt
+++ b/apps/pg-simulator/src/main/kotlin/com/loopers/application/payment/OrderInfo.kt
@@ -1,0 +1,14 @@
+package com.loopers.application.payment
+
+/**
+ * 결제 주문 정보
+ *
+ * 결제는 주문에 대한 다수 트랜잭션으로 구성됩니다.
+ *
+ * @property orderId 주문 정보
+ * @property transactions 주문에 엮인 트랜잭션 목록
+ */
+data class OrderInfo(
+    val orderId: String,
+    val transactions: List<TransactionInfo>,
+)

--- a/apps/pg-simulator/src/main/kotlin/com/loopers/application/payment/PaymentApplicationService.kt
+++ b/apps/pg-simulator/src/main/kotlin/com/loopers/application/payment/PaymentApplicationService.kt
@@ -1,0 +1,88 @@
+package com.loopers.application.payment
+
+import com.loopers.domain.payment.Payment
+import com.loopers.domain.payment.PaymentEvent
+import com.loopers.domain.payment.PaymentEventPublisher
+import com.loopers.domain.payment.PaymentRelay
+import com.loopers.domain.payment.PaymentRepository
+import com.loopers.domain.payment.TransactionKeyGenerator
+import com.loopers.domain.user.UserInfo
+import com.loopers.support.error.CoreException
+import com.loopers.support.error.ErrorType
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+
+@Component
+class PaymentApplicationService(
+    private val paymentRepository: PaymentRepository,
+    private val paymentEventPublisher: PaymentEventPublisher,
+    private val paymentRelay: PaymentRelay,
+    private val transactionKeyGenerator: TransactionKeyGenerator,
+) {
+    companion object {
+        private val RATE_LIMIT_EXCEEDED = (1..20)
+        private val RATE_INVALID_CARD = (21..30)
+    }
+
+    @Transactional
+    fun createTransaction(command: PaymentCommand.CreateTransaction): TransactionInfo {
+        command.validate()
+
+        val transactionKey = transactionKeyGenerator.generate()
+        val payment = paymentRepository.save(
+            Payment(
+                transactionKey = transactionKey,
+                userId = command.userId,
+                orderId = command.orderId,
+                cardType = command.cardType,
+                cardNo = command.cardNo,
+                amount = command.amount,
+                callbackUrl = command.callbackUrl,
+            ),
+        )
+
+        paymentEventPublisher.publish(PaymentEvent.PaymentCreated.from(payment = payment))
+
+        return TransactionInfo.from(payment)
+    }
+
+    @Transactional(readOnly = true)
+    fun getTransactionDetailInfo(userInfo: UserInfo, transactionKey: String): TransactionInfo {
+        val payment = paymentRepository.findByTransactionKey(userId = userInfo.userId, transactionKey = transactionKey)
+            ?: throw CoreException(ErrorType.NOT_FOUND, "(transactionKey: $transactionKey) 결제건이 존재하지 않습니다.")
+        return TransactionInfo.from(payment)
+    }
+
+    @Transactional(readOnly = true)
+    fun findTransactionsByOrderId(userInfo: UserInfo, orderId: String): OrderInfo {
+        val payments = paymentRepository.findByOrderId(userId = userInfo.userId, orderId = orderId)
+        if (payments.isEmpty()) {
+            throw CoreException(ErrorType.NOT_FOUND, "(orderId: $orderId) 에 해당하는 결제건이 존재하지 않습니다.")
+        }
+
+        return OrderInfo(
+            orderId = orderId,
+            transactions = payments.map { TransactionInfo.from(it) },
+        )
+    }
+
+    @Transactional
+    fun handle(transactionKey: String) {
+        val payment = paymentRepository.findByTransactionKey(transactionKey)
+            ?: throw CoreException(ErrorType.NOT_FOUND, "(transactionKey: $transactionKey) 결제건이 존재하지 않습니다.")
+
+        val rate = (1..100).random()
+        when (rate) {
+            in RATE_LIMIT_EXCEEDED -> payment.limitExceeded()
+            in RATE_INVALID_CARD -> payment.invalidCard()
+            else -> payment.approve()
+        }
+        paymentEventPublisher.publish(event = PaymentEvent.PaymentHandled.from(payment))
+    }
+
+    fun notifyTransactionResult(transactionKey: String) {
+        val payment = paymentRepository.findByTransactionKey(transactionKey)
+            ?: throw CoreException(ErrorType.NOT_FOUND, "(transactionKey: $transactionKey) 결제건이 존재하지 않습니다.")
+        paymentRelay.notify(callbackUrl = payment.callbackUrl, transactionInfo = TransactionInfo.from(payment))
+    }
+}

--- a/apps/pg-simulator/src/main/kotlin/com/loopers/application/payment/PaymentCommand.kt
+++ b/apps/pg-simulator/src/main/kotlin/com/loopers/application/payment/PaymentCommand.kt
@@ -1,0 +1,22 @@
+package com.loopers.application.payment
+
+import com.loopers.domain.payment.CardType
+import com.loopers.support.error.CoreException
+import com.loopers.support.error.ErrorType
+
+object PaymentCommand {
+    data class CreateTransaction(
+        val userId: String,
+        val orderId: String,
+        val cardType: CardType,
+        val cardNo: String,
+        val amount: Long,
+        val callbackUrl: String,
+    ) {
+        fun validate() {
+            if (amount <= 0L) {
+                throw CoreException(ErrorType.BAD_REQUEST, "요청 금액은 0 보다 큰 정수여야 합니다.")
+            }
+        }
+    }
+}

--- a/apps/pg-simulator/src/main/kotlin/com/loopers/application/payment/TransactionInfo.kt
+++ b/apps/pg-simulator/src/main/kotlin/com/loopers/application/payment/TransactionInfo.kt
@@ -1,0 +1,39 @@
+package com.loopers.application.payment
+
+import com.loopers.domain.payment.CardType
+import com.loopers.domain.payment.Payment
+import com.loopers.domain.payment.TransactionStatus
+
+/**
+ * 트랜잭션 정보
+ *
+ * @property transactionKey 트랜잭션 KEY
+ * @property orderId 주문 ID
+ * @property cardType 카드 종류
+ * @property cardNo 카드 번호
+ * @property amount 금액
+ * @property status 처리 상태
+ * @property reason 처리 사유
+ */
+data class TransactionInfo(
+    val transactionKey: String,
+    val orderId: String,
+    val cardType: CardType,
+    val cardNo: String,
+    val amount: Long,
+    val status: TransactionStatus,
+    val reason: String?,
+) {
+    companion object {
+        fun from(payment: Payment): TransactionInfo =
+            TransactionInfo(
+                transactionKey = payment.transactionKey,
+                orderId = payment.orderId,
+                cardType = payment.cardType,
+                cardNo = payment.cardNo,
+                amount = payment.amount,
+                status = payment.status,
+                reason = payment.reason,
+            )
+    }
+}

--- a/apps/pg-simulator/src/main/kotlin/com/loopers/config/web/WebMvcConfig.kt
+++ b/apps/pg-simulator/src/main/kotlin/com/loopers/config/web/WebMvcConfig.kt
@@ -1,0 +1,13 @@
+package com.loopers.config.web
+
+import com.loopers.interfaces.api.argumentresolver.UserInfoArgumentResolver
+import org.springframework.context.annotation.Configuration
+import org.springframework.web.method.support.HandlerMethodArgumentResolver
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
+
+@Configuration
+class WebMvcConfig : WebMvcConfigurer {
+    override fun addArgumentResolvers(resolvers: MutableList<HandlerMethodArgumentResolver?>) {
+        resolvers.add(UserInfoArgumentResolver())
+    }
+}

--- a/apps/pg-simulator/src/main/kotlin/com/loopers/domain/payment/CardType.kt
+++ b/apps/pg-simulator/src/main/kotlin/com/loopers/domain/payment/CardType.kt
@@ -1,0 +1,7 @@
+package com.loopers.domain.payment
+
+enum class CardType {
+    SAMSUNG,
+    KB,
+    HYUNDAI,
+}

--- a/apps/pg-simulator/src/main/kotlin/com/loopers/domain/payment/Payment.kt
+++ b/apps/pg-simulator/src/main/kotlin/com/loopers/domain/payment/Payment.kt
@@ -1,0 +1,87 @@
+package com.loopers.domain.payment
+
+import com.loopers.support.error.CoreException
+import com.loopers.support.error.ErrorType
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.Id
+import jakarta.persistence.Index
+import jakarta.persistence.Table
+import java.time.LocalDateTime
+
+@Entity
+@Table(
+    name = "payments",
+    indexes = [
+        Index(name = "idx_user_transaction", columnList = "user_id, transaction_key"),
+        Index(name = "idx_user_order", columnList = "user_id, order_id"),
+        Index(name = "idx_unique_user_order_transaction", columnList = "user_id, order_id, transaction_key", unique = true),
+    ]
+)
+class Payment(
+    @Id
+    @Column(name = "transaction_key", nullable = false, unique = true)
+    val transactionKey: String,
+
+    @Column(name = "user_id", nullable = false)
+    val userId: String,
+
+    @Column(name = "order_id", nullable = false)
+    val orderId: String,
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "card_type", nullable = false)
+    val cardType: CardType,
+
+    @Column(name = "card_no", nullable = false)
+    val cardNo: String,
+
+    @Column(name = "amount", nullable = false)
+    val amount: Long,
+
+    @Column(name = "callback_url", nullable = false)
+    val callbackUrl: String,
+) {
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false)
+    var status: TransactionStatus = TransactionStatus.PENDING
+        private set
+
+    @Column(name = "reason", nullable = true)
+    var reason: String? = null
+        private set
+
+    @Column(name = "created_at", nullable = false)
+    var createdAt: LocalDateTime = LocalDateTime.now()
+        private set
+
+    @Column(name = "updated_at", nullable = false)
+    var updatedAt: LocalDateTime = LocalDateTime.now()
+        private set
+
+    fun approve() {
+        if (status != TransactionStatus.PENDING) {
+            throw CoreException(ErrorType.INTERNAL_ERROR, "결제승인은 대기상태에서만 가능합니다.")
+        }
+        status = TransactionStatus.SUCCESS
+        reason = "정상 승인되었습니다."
+    }
+
+    fun invalidCard() {
+        if (status != TransactionStatus.PENDING) {
+            throw CoreException(ErrorType.INTERNAL_ERROR, "결제처리는 대기상태에서만 가능합니다.")
+        }
+        status = TransactionStatus.FAILED
+        reason = "잘못된 카드입니다. 다른 카드를 선택해주세요."
+    }
+
+    fun limitExceeded() {
+        if (status != TransactionStatus.PENDING) {
+            throw CoreException(ErrorType.INTERNAL_ERROR, "한도초과 처리는 대기상태에서만 가능합니다.")
+        }
+        status = TransactionStatus.FAILED
+        reason = "한도초과입니다. 다른 카드를 선택해주세요."
+    }
+}

--- a/apps/pg-simulator/src/main/kotlin/com/loopers/domain/payment/Payment.kt
+++ b/apps/pg-simulator/src/main/kotlin/com/loopers/domain/payment/Payment.kt
@@ -18,7 +18,7 @@ import java.time.LocalDateTime
         Index(name = "idx_user_transaction", columnList = "user_id, transaction_key"),
         Index(name = "idx_user_order", columnList = "user_id, order_id"),
         Index(name = "idx_unique_user_order_transaction", columnList = "user_id, order_id, transaction_key", unique = true),
-    ]
+    ],
 )
 class Payment(
     @Id

--- a/apps/pg-simulator/src/main/kotlin/com/loopers/domain/payment/PaymentEvent.kt
+++ b/apps/pg-simulator/src/main/kotlin/com/loopers/domain/payment/PaymentEvent.kt
@@ -1,0 +1,28 @@
+package com.loopers.domain.payment
+
+object PaymentEvent {
+    data class PaymentCreated(
+        val transactionKey: String,
+    ) {
+        companion object {
+            fun from(payment: Payment): PaymentCreated = PaymentCreated(transactionKey = payment.transactionKey)
+        }
+    }
+
+    data class PaymentHandled(
+        val transactionKey: String,
+        val status: TransactionStatus,
+        val reason: String?,
+        val callbackUrl: String,
+    ) {
+        companion object {
+            fun from(payment: Payment): PaymentHandled =
+                PaymentHandled(
+                    transactionKey = payment.transactionKey,
+                    status = payment.status,
+                    reason = payment.reason,
+                    callbackUrl = payment.callbackUrl,
+                )
+        }
+    }
+}

--- a/apps/pg-simulator/src/main/kotlin/com/loopers/domain/payment/PaymentEventPublisher.kt
+++ b/apps/pg-simulator/src/main/kotlin/com/loopers/domain/payment/PaymentEventPublisher.kt
@@ -1,0 +1,6 @@
+package com.loopers.domain.payment
+
+interface PaymentEventPublisher {
+    fun publish(event: PaymentEvent.PaymentCreated)
+    fun publish(event: PaymentEvent.PaymentHandled)
+}

--- a/apps/pg-simulator/src/main/kotlin/com/loopers/domain/payment/PaymentRelay.kt
+++ b/apps/pg-simulator/src/main/kotlin/com/loopers/domain/payment/PaymentRelay.kt
@@ -1,0 +1,7 @@
+package com.loopers.domain.payment
+
+import com.loopers.application.payment.TransactionInfo
+
+interface PaymentRelay {
+    fun notify(callbackUrl: String, transactionInfo: TransactionInfo)
+}

--- a/apps/pg-simulator/src/main/kotlin/com/loopers/domain/payment/PaymentRepository.kt
+++ b/apps/pg-simulator/src/main/kotlin/com/loopers/domain/payment/PaymentRepository.kt
@@ -1,0 +1,8 @@
+package com.loopers.domain.payment
+
+interface PaymentRepository {
+    fun save(payment: Payment): Payment
+    fun findByTransactionKey(transactionKey: String): Payment?
+    fun findByTransactionKey(userId: String, transactionKey: String): Payment?
+    fun findByOrderId(userId: String, orderId: String): List<Payment>
+}

--- a/apps/pg-simulator/src/main/kotlin/com/loopers/domain/payment/TransactionKeyGenerator.kt
+++ b/apps/pg-simulator/src/main/kotlin/com/loopers/domain/payment/TransactionKeyGenerator.kt
@@ -1,0 +1,20 @@
+package com.loopers.domain.payment
+
+import org.springframework.stereotype.Component
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+import java.util.UUID
+
+@Component
+class TransactionKeyGenerator {
+    companion object {
+        private const val KEY_TRANSACTION = "TR"
+        private val DATETIME_FORMATTER = DateTimeFormatter.ofPattern("yyyyMMdd")
+    }
+
+    fun generate(): String {
+        val now = LocalDateTime.now()
+        val uuid = UUID.randomUUID().toString().replace("-", "").substring(0, 6)
+        return "${DATETIME_FORMATTER.format(now)}:$KEY_TRANSACTION:$uuid"
+    }
+}

--- a/apps/pg-simulator/src/main/kotlin/com/loopers/domain/payment/TransactionStatus.kt
+++ b/apps/pg-simulator/src/main/kotlin/com/loopers/domain/payment/TransactionStatus.kt
@@ -1,0 +1,7 @@
+package com.loopers.domain.payment
+
+enum class TransactionStatus {
+    PENDING,
+    SUCCESS,
+    FAILED
+}

--- a/apps/pg-simulator/src/main/kotlin/com/loopers/domain/payment/TransactionStatus.kt
+++ b/apps/pg-simulator/src/main/kotlin/com/loopers/domain/payment/TransactionStatus.kt
@@ -3,5 +3,5 @@ package com.loopers.domain.payment
 enum class TransactionStatus {
     PENDING,
     SUCCESS,
-    FAILED
+    FAILED,
 }

--- a/apps/pg-simulator/src/main/kotlin/com/loopers/domain/user/UserInfo.kt
+++ b/apps/pg-simulator/src/main/kotlin/com/loopers/domain/user/UserInfo.kt
@@ -1,0 +1,8 @@
+package com.loopers.domain.user
+
+/**
+ * user 정보
+ *
+ * @param userId 유저 식별자
+ */
+data class UserInfo(val userId: String)

--- a/apps/pg-simulator/src/main/kotlin/com/loopers/infrastructure/payment/PaymentCoreEventPublisher.kt
+++ b/apps/pg-simulator/src/main/kotlin/com/loopers/infrastructure/payment/PaymentCoreEventPublisher.kt
@@ -1,0 +1,19 @@
+package com.loopers.infrastructure.payment
+
+import com.loopers.domain.payment.PaymentEvent
+import com.loopers.domain.payment.PaymentEventPublisher
+import org.springframework.context.ApplicationEventPublisher
+import org.springframework.stereotype.Component
+
+@Component
+class PaymentCoreEventPublisher(
+    private val applicationEventPublisher: ApplicationEventPublisher,
+) : PaymentEventPublisher {
+    override fun publish(event: PaymentEvent.PaymentCreated) {
+        applicationEventPublisher.publishEvent(event)
+    }
+
+    override fun publish(event: PaymentEvent.PaymentHandled) {
+        applicationEventPublisher.publishEvent(event)
+    }
+}

--- a/apps/pg-simulator/src/main/kotlin/com/loopers/infrastructure/payment/PaymentCoreRelay.kt
+++ b/apps/pg-simulator/src/main/kotlin/com/loopers/infrastructure/payment/PaymentCoreRelay.kt
@@ -1,0 +1,21 @@
+package com.loopers.infrastructure.payment
+
+import com.loopers.application.payment.TransactionInfo
+import com.loopers.domain.payment.PaymentRelay
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Component
+import org.springframework.web.client.RestTemplate
+
+@Component
+class PaymentCoreRelay : PaymentRelay {
+    companion object {
+        private val logger = LoggerFactory.getLogger(PaymentCoreRelay::class.java)
+        private val restTemplate = RestTemplate()
+    }
+
+    override fun notify(callbackUrl: String, transactionInfo: TransactionInfo) {
+        runCatching {
+            restTemplate.postForEntity(callbackUrl, transactionInfo, Any::class.java)
+        }.onFailure { e -> logger.error("콜백 호출을 실패했습니다. {}", e.message, e) }
+    }
+}

--- a/apps/pg-simulator/src/main/kotlin/com/loopers/infrastructure/payment/PaymentCoreRepository.kt
+++ b/apps/pg-simulator/src/main/kotlin/com/loopers/infrastructure/payment/PaymentCoreRepository.kt
@@ -1,0 +1,32 @@
+package com.loopers.infrastructure.payment
+
+import com.loopers.domain.payment.Payment
+import com.loopers.domain.payment.PaymentRepository
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+import kotlin.jvm.optionals.getOrNull
+
+@Component
+class PaymentCoreRepository(
+    private val paymentJpaRepository: PaymentJpaRepository,
+) : PaymentRepository {
+    @Transactional
+    override fun save(payment: Payment): Payment {
+        return paymentJpaRepository.save(payment)
+    }
+
+    @Transactional(readOnly = true)
+    override fun findByTransactionKey(transactionKey: String): Payment? {
+        return paymentJpaRepository.findById(transactionKey).getOrNull()
+    }
+
+    @Transactional(readOnly = true)
+    override fun findByTransactionKey(userId: String, transactionKey: String): Payment? {
+        return paymentJpaRepository.findByUserIdAndTransactionKey(userId, transactionKey)
+    }
+
+    override fun findByOrderId(userId: String, orderId: String): List<Payment> {
+        return paymentJpaRepository.findByUserIdAndOrderId(userId, orderId)
+            .sortedByDescending { it.updatedAt }
+    }
+}

--- a/apps/pg-simulator/src/main/kotlin/com/loopers/infrastructure/payment/PaymentJpaRepository.kt
+++ b/apps/pg-simulator/src/main/kotlin/com/loopers/infrastructure/payment/PaymentJpaRepository.kt
@@ -1,0 +1,9 @@
+package com.loopers.infrastructure.payment
+
+import com.loopers.domain.payment.Payment
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface PaymentJpaRepository : JpaRepository<Payment, String> {
+    fun findByUserIdAndTransactionKey(userId: String, transactionKey: String): Payment?
+    fun findByUserIdAndOrderId(userId: String, orderId: String): List<Payment>
+}

--- a/apps/pg-simulator/src/main/kotlin/com/loopers/interfaces/api/ApiControllerAdvice.kt
+++ b/apps/pg-simulator/src/main/kotlin/com/loopers/interfaces/api/ApiControllerAdvice.kt
@@ -1,0 +1,119 @@
+package com.loopers.interfaces.api
+
+import com.fasterxml.jackson.databind.JsonMappingException
+import com.fasterxml.jackson.databind.exc.InvalidFormatException
+import com.fasterxml.jackson.databind.exc.MismatchedInputException
+import com.loopers.support.error.CoreException
+import com.loopers.support.error.ErrorType
+import org.slf4j.LoggerFactory
+import org.springframework.http.ResponseEntity
+import org.springframework.http.converter.HttpMessageNotReadableException
+import org.springframework.web.bind.MissingServletRequestParameterException
+import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.bind.annotation.RestControllerAdvice
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException
+import org.springframework.web.server.ServerWebInputException
+import org.springframework.web.servlet.resource.NoResourceFoundException
+import kotlin.collections.joinToString
+import kotlin.jvm.java
+import kotlin.text.isNotEmpty
+import kotlin.text.toRegex
+
+@RestControllerAdvice
+class ApiControllerAdvice {
+    private val log = LoggerFactory.getLogger(ApiControllerAdvice::class.java)
+
+    @ExceptionHandler
+    fun handle(e: CoreException): ResponseEntity<ApiResponse<*>> {
+        log.warn("CoreException : {}", e.customMessage ?: e.message, e)
+        return failureResponse(errorType = e.errorType, errorMessage = e.customMessage)
+    }
+
+    @ExceptionHandler
+    fun handleBadRequest(e: MethodArgumentTypeMismatchException): ResponseEntity<ApiResponse<*>> {
+        val name = e.name
+        val type = e.requiredType?.simpleName ?: "unknown"
+        val value = e.value ?: "null"
+        val message = "요청 파라미터 '$name' (타입: $type)의 값 '$value'이(가) 잘못되었습니다."
+        return failureResponse(errorType = ErrorType.BAD_REQUEST, errorMessage = message)
+    }
+
+    @ExceptionHandler
+    fun handleBadRequest(e: MissingServletRequestParameterException): ResponseEntity<ApiResponse<*>> {
+        val name = e.parameterName
+        val type = e.parameterType
+        val message = "필수 요청 파라미터 '$name' (타입: $type)가 누락되었습니다."
+        return failureResponse(errorType = ErrorType.BAD_REQUEST, errorMessage = message)
+    }
+
+    @ExceptionHandler
+    fun handleBadRequest(e: HttpMessageNotReadableException): ResponseEntity<ApiResponse<*>> {
+        val errorMessage = when (val rootCause = e.rootCause) {
+            is InvalidFormatException -> {
+                val fieldName = rootCause.path.joinToString(".") { it.fieldName ?: "?" }
+
+                val valueIndicationMessage = when {
+                    rootCause.targetType.isEnum -> {
+                        val enumClass = rootCause.targetType
+                        val enumValues = enumClass.enumConstants.joinToString(", ") { it.toString() }
+                        "사용 가능한 값 : [$enumValues]"
+                    }
+
+                    else -> ""
+                }
+
+                val expectedType = rootCause.targetType.simpleName
+                val value = rootCause.value
+
+                "필드 '$fieldName'의 값 '$value'이(가) 예상 타입($expectedType)과 일치하지 않습니다. $valueIndicationMessage"
+            }
+
+            is MismatchedInputException -> {
+                val fieldPath = rootCause.path.joinToString(".") { it.fieldName ?: "?" }
+                "필수 필드 '$fieldPath'이(가) 누락되었습니다."
+            }
+
+            is JsonMappingException -> {
+                val fieldPath = rootCause.path.joinToString(".") { it.fieldName ?: "?" }
+                "필드 '$fieldPath'에서 JSON 매핑 오류가 발생했습니다: ${rootCause.originalMessage}"
+            }
+
+            else -> "요청 본문을 처리하는 중 오류가 발생했습니다. JSON 메세지 규격을 확인해주세요."
+        }
+
+        return failureResponse(errorType = ErrorType.BAD_REQUEST, errorMessage = errorMessage)
+    }
+
+    @ExceptionHandler
+    fun handleBadRequest(e: ServerWebInputException): ResponseEntity<ApiResponse<*>> {
+        fun extractMissingParameter(message: String): String {
+            val regex = "'(.+?)'".toRegex()
+            return regex.find(message)?.groupValues?.get(1) ?: ""
+        }
+
+        val missingParams = extractMissingParameter(e.reason ?: "")
+        return if (missingParams.isNotEmpty()) {
+            failureResponse(errorType = ErrorType.BAD_REQUEST, errorMessage = "필수 요청 값 \'$missingParams\'가 누락되었습니다.")
+        } else {
+            failureResponse(errorType = ErrorType.BAD_REQUEST)
+        }
+    }
+
+    @ExceptionHandler
+    fun handleNotFound(e: NoResourceFoundException): ResponseEntity<ApiResponse<*>> {
+        return failureResponse(errorType = ErrorType.NOT_FOUND)
+    }
+
+    @ExceptionHandler
+    fun handle(e: Throwable): ResponseEntity<ApiResponse<*>> {
+        log.error("Exception : {}", e.message, e)
+        val errorType = ErrorType.INTERNAL_ERROR
+        return failureResponse(errorType = errorType)
+    }
+
+    private fun failureResponse(errorType: ErrorType, errorMessage: String? = null): ResponseEntity<ApiResponse<*>> =
+        ResponseEntity(
+            ApiResponse.fail(errorCode = errorType.code, errorMessage = errorMessage ?: errorType.message),
+            errorType.status,
+        )
+}

--- a/apps/pg-simulator/src/main/kotlin/com/loopers/interfaces/api/ApiResponse.kt
+++ b/apps/pg-simulator/src/main/kotlin/com/loopers/interfaces/api/ApiResponse.kt
@@ -1,0 +1,32 @@
+package com.loopers.interfaces.api
+
+data class ApiResponse<T>(
+    val meta: Metadata,
+    val data: T?,
+) {
+    data class Metadata(
+        val result: Result,
+        val errorCode: String?,
+        val message: String?,
+    ) {
+        enum class Result { SUCCESS, FAIL }
+
+        companion object {
+            fun success() = Metadata(Result.SUCCESS, null, null)
+
+            fun fail(errorCode: String, errorMessage: String) = Metadata(Result.FAIL, errorCode, errorMessage)
+        }
+    }
+
+    companion object {
+        fun success(): ApiResponse<Any> = ApiResponse(Metadata.success(), null)
+
+        fun <T> success(data: T? = null) = ApiResponse(Metadata.success(), data)
+
+        fun fail(errorCode: String, errorMessage: String): ApiResponse<Any?> =
+            ApiResponse(
+                meta = Metadata.fail(errorCode = errorCode, errorMessage = errorMessage),
+                data = null,
+            )
+    }
+}

--- a/apps/pg-simulator/src/main/kotlin/com/loopers/interfaces/api/argumentresolver/UserInfoArgumentResolver.kt
+++ b/apps/pg-simulator/src/main/kotlin/com/loopers/interfaces/api/argumentresolver/UserInfoArgumentResolver.kt
@@ -1,0 +1,32 @@
+package com.loopers.interfaces.api.argumentresolver
+
+import com.loopers.domain.user.UserInfo
+import com.loopers.support.error.CoreException
+import com.loopers.support.error.ErrorType
+import org.springframework.core.MethodParameter
+import org.springframework.web.bind.support.WebDataBinderFactory
+import org.springframework.web.context.request.NativeWebRequest
+import org.springframework.web.method.support.HandlerMethodArgumentResolver
+import org.springframework.web.method.support.ModelAndViewContainer
+
+class UserInfoArgumentResolver: HandlerMethodArgumentResolver {
+    companion object {
+        private const val KEY_USER_ID = "X-USER-ID"
+    }
+
+    override fun supportsParameter(parameter: MethodParameter): Boolean {
+        return UserInfo::class.java.isAssignableFrom(parameter.parameterType)
+    }
+
+    override fun resolveArgument(
+        parameter: MethodParameter,
+        mavContainer: ModelAndViewContainer?,
+        webRequest: NativeWebRequest,
+        binderFactory: WebDataBinderFactory?,
+    ): UserInfo {
+        val userId = webRequest.getHeader(KEY_USER_ID)
+            ?: throw CoreException(ErrorType.BAD_REQUEST, "유저 ID 헤더는 필수입니다.")
+
+        return UserInfo(userId)
+    }
+}

--- a/apps/pg-simulator/src/main/kotlin/com/loopers/interfaces/api/argumentresolver/UserInfoArgumentResolver.kt
+++ b/apps/pg-simulator/src/main/kotlin/com/loopers/interfaces/api/argumentresolver/UserInfoArgumentResolver.kt
@@ -9,7 +9,7 @@ import org.springframework.web.context.request.NativeWebRequest
 import org.springframework.web.method.support.HandlerMethodArgumentResolver
 import org.springframework.web.method.support.ModelAndViewContainer
 
-class UserInfoArgumentResolver: HandlerMethodArgumentResolver {
+class UserInfoArgumentResolver : HandlerMethodArgumentResolver {
     companion object {
         private const val KEY_USER_ID = "X-USER-ID"
     }

--- a/apps/pg-simulator/src/main/kotlin/com/loopers/interfaces/api/payment/PaymentApi.kt
+++ b/apps/pg-simulator/src/main/kotlin/com/loopers/interfaces/api/payment/PaymentApi.kt
@@ -1,0 +1,60 @@
+package com.loopers.interfaces.api.payment
+
+import com.loopers.application.payment.PaymentApplicationService
+import com.loopers.interfaces.api.ApiResponse
+import com.loopers.domain.user.UserInfo
+import com.loopers.support.error.CoreException
+import com.loopers.support.error.ErrorType
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/v1/payments")
+class PaymentApi(
+    private val paymentApplicationService: PaymentApplicationService,
+) {
+    @PostMapping
+    fun request(
+        userInfo: UserInfo,
+        @RequestBody request: PaymentDto.PaymentRequest,
+    ): ApiResponse<PaymentDto.TransactionResponse> {
+        request.validate()
+
+        // 100ms ~ 500ms 지연
+        Thread.sleep((100..500L).random())
+
+        // 40% 확률로 요청 실패
+        if ((1..100).random() <= 40) {
+            throw CoreException(ErrorType.INTERNAL_ERROR, "현재 서버가 불안정합니다. 잠시 후 다시 시도해주세요.")
+        }
+
+        return paymentApplicationService.createTransaction(request.toCommand(userInfo.userId))
+            .let { PaymentDto.TransactionResponse.from(it) }
+            .let { ApiResponse.success(it) }
+    }
+
+    @GetMapping("/{transactionKey}")
+    fun getTransaction(
+        userInfo: UserInfo,
+        @PathVariable("transactionKey") transactionKey: String,
+    ): ApiResponse<PaymentDto.TransactionDetailResponse> {
+        return paymentApplicationService.getTransactionDetailInfo(userInfo, transactionKey)
+            .let { PaymentDto.TransactionDetailResponse.from(it) }
+            .let { ApiResponse.success(it) }
+    }
+
+    @GetMapping
+    fun getTransactionsByOrder(
+        userInfo: UserInfo,
+        @RequestParam("orderId", required = false) orderId: String,
+    ): ApiResponse<PaymentDto.OrderResponse> {
+        return paymentApplicationService.findTransactionsByOrderId(userInfo, orderId)
+            .let { PaymentDto.OrderResponse.from(it) }
+            .let { ApiResponse.success(it) }
+    }
+}

--- a/apps/pg-simulator/src/main/kotlin/com/loopers/interfaces/api/payment/PaymentDto.kt
+++ b/apps/pg-simulator/src/main/kotlin/com/loopers/interfaces/api/payment/PaymentDto.kt
@@ -1,0 +1,136 @@
+package com.loopers.interfaces.api.payment
+
+import com.loopers.application.payment.OrderInfo
+import com.loopers.application.payment.PaymentCommand
+import com.loopers.application.payment.TransactionInfo
+import com.loopers.domain.payment.CardType
+import com.loopers.domain.payment.TransactionStatus
+import com.loopers.support.error.CoreException
+import com.loopers.support.error.ErrorType
+
+object PaymentDto {
+    data class PaymentRequest(
+        val orderId: String,
+        val cardType: CardTypeDto,
+        val cardNo: String,
+        val amount: Long,
+        val callbackUrl: String,
+    ) {
+        companion object {
+            private val REGEX_CARD_NO = Regex("^\\d{4}-\\d{4}-\\d{4}-\\d{4}$")
+            private const val PREFIX_CALLBACK_URL = "http://localhost:8080"
+        }
+
+        fun validate() {
+            if (orderId.isBlank() || orderId.length < 6) {
+                throw CoreException(ErrorType.BAD_REQUEST, "주문 ID는 6자리 이상 문자열이어야 합니다.")
+            }
+            if (!REGEX_CARD_NO.matches(cardNo)) {
+                throw CoreException(ErrorType.BAD_REQUEST, "카드 번호는 xxxx-xxxx-xxxx-xxxx 형식이어야 합니다.")
+            }
+            if (amount <= 0) {
+                throw CoreException(ErrorType.BAD_REQUEST, "결제금액은 양의 정수여야 합니다.")
+            }
+            if (!callbackUrl.startsWith(PREFIX_CALLBACK_URL)) {
+                throw CoreException(ErrorType.BAD_REQUEST, "콜백 URL 은 $PREFIX_CALLBACK_URL 로 시작해야 합니다.")
+            }
+        }
+
+        fun toCommand(userId: String): PaymentCommand.CreateTransaction =
+            PaymentCommand.CreateTransaction(
+                userId = userId,
+                orderId = orderId,
+                cardType = cardType.toCardType(),
+                cardNo = cardNo,
+                amount = amount,
+                callbackUrl = callbackUrl,
+            )
+    }
+
+    data class TransactionDetailResponse(
+        val transactionKey: String,
+        val orderId: String,
+        val cardType: CardTypeDto,
+        val cardNo: String,
+        val amount: Long,
+        val status: TransactionStatusResponse,
+        val reason: String?,
+    ) {
+        companion object {
+            fun from(transactionInfo: TransactionInfo): TransactionDetailResponse =
+                TransactionDetailResponse(
+                    transactionKey = transactionInfo.transactionKey,
+                    orderId = transactionInfo.orderId,
+                    cardType = CardTypeDto.from(transactionInfo.cardType),
+                    cardNo = transactionInfo.cardNo,
+                    amount = transactionInfo.amount,
+                    status = TransactionStatusResponse.from(transactionInfo.status),
+                    reason = transactionInfo.reason,
+                )
+        }
+    }
+
+    data class TransactionResponse(
+        val transactionKey: String,
+        val status: TransactionStatusResponse,
+        val reason: String?,
+    ) {
+        companion object {
+            fun from(transactionInfo: TransactionInfo): TransactionResponse =
+                TransactionResponse(
+                    transactionKey = transactionInfo.transactionKey,
+                    status = TransactionStatusResponse.from(transactionInfo.status),
+                    reason = transactionInfo.reason,
+                )
+        }
+    }
+
+    data class OrderResponse(
+        val orderId: String,
+        val transactions: List<TransactionResponse>,
+    ) {
+        companion object {
+            fun from(orderInfo: OrderInfo): OrderResponse =
+                OrderResponse(
+                    orderId = orderInfo.orderId,
+                    transactions = orderInfo.transactions.map { TransactionResponse.from(it) },
+                )
+        }
+    }
+
+    enum class CardTypeDto {
+        SAMSUNG,
+        KB,
+        HYUNDAI,
+        ;
+
+        fun toCardType(): CardType = when (this) {
+            SAMSUNG -> CardType.SAMSUNG
+            KB -> CardType.KB
+            HYUNDAI -> CardType.HYUNDAI
+        }
+
+        companion object {
+            fun from(cardType: CardType) = when (cardType) {
+                CardType.SAMSUNG -> SAMSUNG
+                CardType.KB -> KB
+                CardType.HYUNDAI -> HYUNDAI
+            }
+        }
+    }
+
+    enum class TransactionStatusResponse {
+        PENDING,
+        SUCCESS,
+        FAILED,
+        ;
+
+        companion object {
+            fun from(transactionStatus: TransactionStatus) = when (transactionStatus) {
+                TransactionStatus.PENDING -> PENDING
+                TransactionStatus.SUCCESS -> SUCCESS
+                TransactionStatus.FAILED -> FAILED
+            }
+        }
+    }
+}

--- a/apps/pg-simulator/src/main/kotlin/com/loopers/interfaces/event/payment/PaymentEventListener.kt
+++ b/apps/pg-simulator/src/main/kotlin/com/loopers/interfaces/event/payment/PaymentEventListener.kt
@@ -1,0 +1,28 @@
+package com.loopers.interfaces.event.payment
+
+import com.loopers.application.payment.PaymentApplicationService
+import com.loopers.domain.payment.PaymentEvent
+import org.springframework.scheduling.annotation.Async
+import org.springframework.stereotype.Component
+import org.springframework.transaction.event.TransactionPhase
+import org.springframework.transaction.event.TransactionalEventListener
+
+@Component
+class PaymentEventListener(
+    private val paymentApplicationService: PaymentApplicationService,
+) {
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    fun handle(event: PaymentEvent.PaymentCreated) {
+        val thresholdMillis = (1000L..5000L).random()
+        Thread.sleep(thresholdMillis)
+
+        paymentApplicationService.handle(event.transactionKey)
+    }
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    fun handle(event: PaymentEvent.PaymentHandled) {
+        paymentApplicationService.notifyTransactionResult(transactionKey = event.transactionKey)
+    }
+}

--- a/apps/pg-simulator/src/main/kotlin/com/loopers/support/error/CoreException.kt
+++ b/apps/pg-simulator/src/main/kotlin/com/loopers/support/error/CoreException.kt
@@ -1,0 +1,6 @@
+package com.loopers.support.error
+
+class CoreException(
+    val errorType: ErrorType,
+    val customMessage: String? = null,
+) : RuntimeException(customMessage ?: errorType.message)

--- a/apps/pg-simulator/src/main/kotlin/com/loopers/support/error/ErrorType.kt
+++ b/apps/pg-simulator/src/main/kotlin/com/loopers/support/error/ErrorType.kt
@@ -1,0 +1,11 @@
+package com.loopers.support.error
+
+import org.springframework.http.HttpStatus
+
+enum class ErrorType(val status: HttpStatus, val code: String, val message: String) {
+    /** 범용 에러 */
+    INTERNAL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, HttpStatus.INTERNAL_SERVER_ERROR.reasonPhrase, "일시적인 오류가 발생했습니다."),
+    BAD_REQUEST(HttpStatus.BAD_REQUEST, HttpStatus.BAD_REQUEST.reasonPhrase, "잘못된 요청입니다."),
+    NOT_FOUND(HttpStatus.NOT_FOUND, HttpStatus.NOT_FOUND.reasonPhrase, "존재하지 않는 요청입니다."),
+    CONFLICT(HttpStatus.CONFLICT, HttpStatus.CONFLICT.reasonPhrase, "이미 존재하는 리소스입니다."),
+}

--- a/apps/pg-simulator/src/main/resources/application.yml
+++ b/apps/pg-simulator/src/main/resources/application.yml
@@ -1,0 +1,77 @@
+server:
+  shutdown: graceful
+  tomcat:
+    threads:
+      max: 200 # 최대 워커 스레드 수 (default : 200)
+      min-spare: 10 # 최소 유지 스레드 수 (default : 10)
+    connection-timeout: 1m # 연결 타임아웃 (ms) (default : 60000ms = 1m)
+    max-connections: 8192 # 최대 동시 연결 수 (default : 8192)
+    accept-count: 100 # 대기 큐 크기 (default : 100)
+    keep-alive-timeout: 60s # 60s
+  max-http-request-header-size: 8KB
+
+spring:
+  main:
+    web-application-type: servlet
+  application:
+    name: commerce-api
+  profiles:
+    active: local
+  config:
+    import:
+      - jpa.yml
+      - redis.yml
+      - logging.yml
+      - monitoring.yml
+
+datasource:
+  mysql-jpa:
+    main:
+      jdbc-url: jdbc:mysql://localhost:3306/paymentgateway
+
+springdoc:
+  use-fqn: true
+  swagger-ui:
+    path: /swagger-ui.html
+
+---
+spring:
+  config:
+    activate:
+      on-profile: local, test
+
+server:
+  port: 8082
+
+management:
+  server:
+    port: 8083
+
+---
+spring:
+  config:
+    activate:
+      on-profile: dev
+
+server:
+  port: 8082
+
+management:
+  server:
+    port: 8083
+
+---
+spring:
+  config:
+    activate:
+      on-profile: qa
+
+---
+spring:
+  config:
+    activate:
+      on-profile: prd
+
+springdoc:
+  api-docs:
+    enabled: false

--- a/http/commerce-api/order-v1.api.http
+++ b/http/commerce-api/order-v1.api.http
@@ -1,0 +1,21 @@
+### 주문 생성
+POST {{commerce-api}}/api/v1/orders
+X-USER-ID: wjsyuwls
+Content-Type: application/json
+
+{
+  "orderItems": [
+    {
+      "productId": 3,
+      "quantity": 1
+    },
+    {
+      "productId": 4,
+      "quantity": 1
+    }
+  ],
+  "couponId": 0,
+  "paymentMethod": "CARD",
+  "cardType": "SAMSUNG",
+  "cardNo": "1234-1234-1234-1234"
+}

--- a/http/commerce-api/user-v1.api.http
+++ b/http/commerce-api/user-v1.api.http
@@ -6,7 +6,7 @@ Content-Type: application/json
   "userId": "wjsyuwls",
   "email": "wjsyuwls@gmail.com",
   "birthdate": "2000-01-01",
-  "gender": "M"
+  "gender": "MALE"
 }
 
 ### 내 정보 조회

--- a/http/http-client.env.json
+++ b/http/http-client.env.json
@@ -1,5 +1,6 @@
 {
   "local": {
-    "commerce-api": "http://localhost:8080"
+    "commerce-api": "http://localhost:8080",
+    "pg-simulator": "http://localhost:8082"
   }
 }

--- a/http/pg-simulator/payments.http
+++ b/http/pg-simulator/payments.http
@@ -1,0 +1,20 @@
+### 결제 요청
+POST {{pg-simulator}}/api/v1/payments
+X-USER-ID: 135135
+Content-Type: application/json
+
+{
+  "orderId": "1351039135",
+  "cardType": "SAMSUNG",
+  "cardNo": "1234-5678-9814-1451",
+  "amount" : "5000",
+  "callbackUrl": "http://localhost:8080/api/v1/examples/callback"
+}
+
+### 결제 정보 확인
+GET {{pg-simulator}}/api/v1/payments/20250816:TR:9577c5
+X-USER-ID: 135135
+
+### 주문에 엮인 결제 정보 조회
+GET {{pg-simulator}}/api/v1/payments?orderId=1351039135
+X-USER-ID: 135135

--- a/modules/redis/src/testFixtures/kotlin/com/loopers/testcontainers/RedisTestContainersConfig.kt
+++ b/modules/redis/src/testFixtures/kotlin/com/loopers/testcontainers/RedisTestContainersConfig.kt
@@ -10,13 +10,13 @@ class RedisTestContainersConfig {
             .apply {
                 start()
             }
-    }
 
-    init {
-        System.setProperty("datasource.redis.database", "0")
-        System.setProperty("datasource.redis.master.host", redisContainer.host)
-        System.setProperty("datasource.redis.host.port", redisContainer.firstMappedPort.toString())
-        System.setProperty("datasource.redis.replicas[0].host", redisContainer.host)
-        System.setProperty("datasource.redis.replicas[0].port", redisContainer.firstMappedPort.toString())
+        init {
+            System.setProperty("datasource.redis.database", "0")
+            System.setProperty("datasource.redis.master.host", redisContainer.host)
+            System.setProperty("datasource.redis.master.port", redisContainer.firstMappedPort.toString())
+            System.setProperty("datasource.redis.replicas[0].host", redisContainer.host)
+            System.setProperty("datasource.redis.replicas[0].port", redisContainer.firstMappedPort.toString())
+        }
     }
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -2,6 +2,7 @@ rootProject.name = "e-commerce"
 
 include(
     ":apps:commerce-api",
+    ":apps:pg-simulator",
     ":modules:jpa",
     ":supports:jackson",
     ":supports:logging",


### PR DESCRIPTION
## 📌 Summary

- [PG 시뮬레이터 연동 및 서킷브레이커 적용](https://github.com/JeonNewJin/e-commerce/commit/82d144d53bcb12139f78d32df013ae633b7f87e6)
- [주문, 결제 트랜잭션 분리](https://github.com/JeonNewJin/e-commerce/commit/cfbb37513e6f00612e5fa4e71f3c07670a3ae8e1)

## 💬 Review Points

- 실무에서 외부 연동 시 서킷브레이커가 OPEN 상태가 된다면, 이에 대한 알림을 별도로 구현하는지 궁금합니다.

- 서킷 브레이커 테스트를 작성하다 보니 케이스가 다양해졌는데, 외부 API마다 서킷 브레이커를 적용한다면 각 엔드포인트에 대해 모든 테스트를 개별적으로 작성하는지 궁금합니다.

## ✅ Checklist

### **⚡ PG 연동 대응**

- [ ]  PG 연동 API는 RestTemplate 혹은 FeignClient 로 외부 시스템을 호출한다.
- [ ]  응답 지연에 대해 타임아웃을 설정하고, 실패 시 적절한 예외 처리 로직을 구현한다.
- [ ]  결제 요청에 대한 실패 응답에 대해 적절한 시스템 연동을 진행한다.
- [ ]  콜백 방식 + **결제 상태 확인 API**를 활용해 적절하게 시스템과 결제정보를 연동한다.

### **🛡 Resilience 설계**

- [ ]  서킷 브레이커 혹은 재시도 정책을 적용하여 장애 확산을 방지한다.
- [ ]  외부 시스템 장애 시에도 내부 시스템은 **정상적으로 응답**하도록 보호한다.
- [ ]  콜백이 오지 않더라도, 일정 주기 혹은 수동 API 호출로 상태를 복구할 수 있다.
- [ ]  PG 에 대한 요청이 타임아웃에 의해 실패되더라도 해당 결제건에 대한 정보를 확인하여 정상적으로 시스템에 반영한다.